### PR TITLE
fix(security): resolve CodeQL findings

### DIFF
--- a/app/src/cli/args.rs
+++ b/app/src/cli/args.rs
@@ -282,8 +282,8 @@ impl ServeArgs {
 pub enum ClientCommand {
   /// Validate a server URL and save it as the active server.
   ///
-  /// Accepts a full URL or the `local` alias to return to the implicit
-  /// local default (http://localhost:8840). Changing servers requires
+  /// Remote servers must use HTTPS. Accepts the `local` alias to return to
+  /// the implicit local default (http://localhost:8840). Changing servers requires
   /// interactive confirmation, stops the current managed background server,
   /// clears the saved CLI session and default, and then requires a new login.
   ///

--- a/app/src/cli/client.rs
+++ b/app/src/cli/client.rs
@@ -1,4 +1,7 @@
-use super::{local_config::ResolvedServer, session};
+use super::{
+  local_config::{ResolvedServer, normalize},
+  session,
+};
 use anyhow::{Context, Result, bail};
 use reqwest::Method;
 use serde_json::{Value, json};
@@ -94,10 +97,14 @@ impl ApiClient {
     server: &ResolvedServer,
     token: Option<String>,
   ) -> Result<Self> {
+    let base_url = normalize(&server.url)?;
+    let https_only = base_url.starts_with("https://");
     Ok(Self {
-      base_url: server.url.clone(),
+      base_url,
       client: reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none())
+        .https_only(https_only)
         .build()?,
       token,
     })
@@ -504,7 +511,7 @@ pub async fn human_client(server: &ResolvedServer) -> Result<ApiClient> {
   })
 }
 
-pub async fn password_confirmed_human_client(server: &ResolvedServer) -> Result<ApiClient> {
+pub async fn recently_authenticated_client(server: &ResolvedServer) -> Result<ApiClient> {
   if !io::stdin().is_terminal() {
     bail!("interactive password confirmation is required for plaintext secret access");
   }

--- a/app/src/cli/commands.rs
+++ b/app/src/cli/commands.rs
@@ -704,7 +704,7 @@ async fn secret(
   json_output: bool,
 ) -> Result<i32> {
   let api = if matches!(&command, SecretCommand::Get { reveal: true, .. }) {
-    client::password_confirmed_human_client(server).await?
+    client::recently_authenticated_client(server).await?
   } else {
     client::human_client(server).await?
   };
@@ -854,7 +854,7 @@ async fn export(
   if stdout && json_output {
     bail!("--stdout and --json cannot be combined");
   }
-  let api = client::password_confirmed_human_client(server).await?;
+  let api = client::recently_authenticated_client(server).await?;
   let env = resolve_environment(&api, reference).await?;
   let data = api
     .request(
@@ -1403,7 +1403,7 @@ async fn restore(
     if !json_output {
       eprintln!("==> [1/3] Authenticating administrator session...");
     }
-    let auth_client = client::password_confirmed_human_client(server).await?;
+    let auth_client = client::recently_authenticated_client(server).await?;
 
     if !json_output {
       eprintln!("==> [2/3] Uploading backup snapshot to server...");

--- a/app/src/cli/local_config.rs
+++ b/app/src/cli/local_config.rs
@@ -1,5 +1,5 @@
 use crate::{
-  config::{client_config_path, ensure_data_dir},
+  config::{client_config_path, ensure_data_dir, validate_endpoint_transport},
   constants::config::{DEFAULT_PUBLIC_URL, ENV_SERVER_URL},
 };
 use anyhow::{Context, Result, bail};
@@ -137,6 +137,7 @@ pub fn normalize(value: &str) -> Result<String> {
   if !matches!(url.scheme(), "http" | "https") {
     bail!("server URL must use HTTP or HTTPS");
   }
+  validate_endpoint_transport(&url)?;
   if !url.username().is_empty() || url.password().is_some() {
     bail!("server URL must not contain credentials");
   }

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use directories::BaseDirs;
 use serde::{Deserialize, Serialize};
-use url::Url;
+use url::{Host, Url};
 
 use crate::constants::config::{
   CLIENT_CONFIG_FILENAME, DATA_DIRECTORY_NAME, DATABASE_FILENAME, DEFAULT_PORT, ENV_BIND_ADDRESS,
@@ -16,6 +16,28 @@ use crate::constants::config::{
   ENV_PUBLIC_URL, ENV_SHUTDOWN_GRACE_SECONDS, MASTER_KEY_FILENAME, SERVER_CONFIG_FILENAME,
 };
 pub use crate::constants::config::{DEFAULT_BIND_ADDRESS, DEFAULT_PUBLIC_URL};
+
+pub fn validate_endpoint_transport(url: &Url) -> Result<()> {
+  if url.scheme() == "https" {
+    return Ok(());
+  }
+  if url.scheme() != "http" {
+    bail!("URL must use HTTP or HTTPS");
+  }
+
+  let is_loopback = match url.host() {
+    Some(Host::Domain(host)) => host == "localhost",
+    Some(Host::Ipv4(host)) => host.is_loopback(),
+    Some(Host::Ipv6(host)) => host.is_loopback(),
+    None => false,
+  };
+  if !is_loopback {
+    bail!(
+      "remote URLs must use HTTPS; HTTP is only allowed for localhost or a loopback IP address"
+    );
+  }
+  Ok(())
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub struct MasterKeyConfig {
@@ -368,6 +390,7 @@ impl ServerConfig {
       if !matches!(public.scheme(), "http" | "https") || public.host_str().is_none() {
         bail!("public_url must be an absolute HTTP or HTTPS URL");
       }
+      validate_endpoint_transport(&public)?;
     } else if !bind.ip().is_loopback() {
       // load() derives public_url for loopback binds before validating, so a
       // non-loopback bind reaching here means the value was never configured.

--- a/app/src/modules/bootstrap/service.rs
+++ b/app/src/modules/bootstrap/service.rs
@@ -182,16 +182,8 @@ pub async fn restore_bootstrap(
     }
   };
 
-  // Generate safe filename for storage
-  let target_key = if filename.ends_with(".dop")
-    && filename
-      .chars()
-      .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '.')
-  {
-    filename.to_string()
-  } else {
-    format!("restore_{}.dop", chrono::Utc::now().format("%Y%m%d_%H%M%S"))
-  };
+  let target_key = crate::modules::backups::service::sanitize_key(filename)
+    .unwrap_or_else(|_| format!("restore_{}.dop", chrono::Utc::now().format("%Y%m%d_%H%M%S")));
 
   // 2. If needs_rekey, re-key the database to the server's master key and re-encrypt the stored backup!
   let (final_bytes, restore_decrypted) = if needs_rekey {

--- a/app/tests/backups.rs
+++ b/app/tests/backups.rs
@@ -1,3 +1,4 @@
+use app::modules::backups::service::{sanitize_key, sanitize_name};
 use app::{config::ServerConfig, server};
 use axum::{
   Router,
@@ -906,4 +907,59 @@ async fn restore_recovers_service_accounts_and_agent_tokens() {
     .unwrap();
   assert_eq!(account_count, 1);
   assert_eq!(token_count, 1);
+}
+
+#[test]
+fn backup_keys_are_single_safe_path_components() {
+  let directory = TempDir::new().unwrap();
+  let backup_directory = directory.path().join("backups");
+
+  for key in ["snapshot.dop", "release_2026-09-07.dop"] {
+    let safe_key = sanitize_key(key).unwrap();
+    let path = backup_directory.join(&safe_key);
+    assert!(path.starts_with(&backup_directory));
+    assert_eq!(path.parent(), Some(backup_directory.as_path()));
+  }
+
+  for key in [
+    "../snapshot.dop",
+    "/tmp/snapshot.dop",
+    r"C:\temp\snapshot.dop",
+    "nested/snapshot.dop",
+    "snapshot..dop",
+    ".dop",
+    "snapshot.dop.exe",
+    "snapshot%2fdanger.dop",
+    "snapshot․report.dop",
+  ] {
+    assert!(
+      sanitize_key(key).is_err(),
+      "expected {key:?} to be rejected"
+    );
+  }
+}
+
+#[test]
+fn backup_names_reject_path_syntax_and_deceptive_extensions() {
+  for name in ["snapshot", "release_2026-09-07", "snapshot.dop"] {
+    assert!(
+      sanitize_name(name).is_ok(),
+      "expected {name:?} to be accepted"
+    );
+  }
+
+  for name in [
+    "../snapshot",
+    "/tmp/snapshot",
+    r"C:\temp\snapshot",
+    "nested/snapshot",
+    "snapshot..dop",
+    "snapshot.dop.exe",
+    "snapshot․report",
+  ] {
+    assert!(
+      sanitize_name(name).is_err(),
+      "expected {name:?} to be rejected"
+    );
+  }
 }

--- a/app/tests/cli/client.rs
+++ b/app/tests/cli/client.rs
@@ -1,10 +1,15 @@
 use app::cli::{
-  client::{ApiClient, CliCancelled, normalize_login_email, password_confirmed_human_client},
+  client::{ApiClient, CliCancelled, normalize_login_email, recently_authenticated_client},
   local_config::{ClientConfig, ResolvedServer, ServerSource},
 };
 use reqwest::Method;
 use std::io::IsTerminal;
 use tempfile::TempDir;
+use tokio::{
+  io::{AsyncReadExt, AsyncWriteExt},
+  net::TcpListener,
+  time::{Duration, timeout},
+};
 
 #[test]
 fn login_email_is_trimmed_lowercased_and_validated() {
@@ -50,7 +55,7 @@ async fn plaintext_access_rejects_non_interactive_execution_before_connecting() 
     },
   };
 
-  let message = password_confirmed_human_client(&server)
+  let message = recently_authenticated_client(&server)
     .await
     .err()
     .unwrap()
@@ -93,4 +98,59 @@ Check that the server is running and verify the active endpoint with `dopbase st
   assert!(!message.contains("error sending request"));
   assert!(!message.contains("tcp connect error"));
   assert!(!message.contains("os error"));
+}
+
+#[test]
+fn api_client_rejects_an_unvalidated_remote_http_server() {
+  let directory = TempDir::new().unwrap();
+  let server = ResolvedServer {
+    url: "http://dopbase.example.com".into(),
+    source: ServerSource::Argument,
+    config_path: directory.path().join("config.toml"),
+    config: ClientConfig::default(),
+  };
+
+  let error = ApiClient::new(&server, Some("secret-token".into()))
+    .err()
+    .unwrap()
+    .to_string();
+  assert!(error.contains("remote URLs must use HTTPS"), "{error}");
+}
+
+#[tokio::test]
+async fn api_client_does_not_follow_redirects() {
+  let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+  let address = listener.local_addr().unwrap();
+  let server_task = tokio::spawn(async move {
+    let (mut stream, _) = listener.accept().await.unwrap();
+    let mut request = [0_u8; 2048];
+    let _ = stream.read(&mut request).await.unwrap();
+    stream
+      .write_all(
+        b"HTTP/1.1 302 Found\r\nLocation: /redirected\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+      )
+      .await
+      .unwrap();
+    stream.shutdown().await.unwrap();
+    timeout(Duration::from_millis(250), listener.accept())
+      .await
+      .is_err()
+  });
+  let directory = TempDir::new().unwrap();
+  let server = ResolvedServer {
+    url: format!("http://{address}"),
+    source: ServerSource::Argument,
+    config_path: directory.path().join("config.toml"),
+    config: ClientConfig::default(),
+  };
+
+  let error = ApiClient::new(&server, Some("secret-token".into()))
+    .unwrap()
+    .request(Method::GET, "/start", None)
+    .await
+    .unwrap_err()
+    .to_string();
+
+  assert!(error.contains("server returned 302 Found"), "{error}");
+  assert!(server_task.await.unwrap(), "client followed the redirect");
 }

--- a/app/tests/cli/local_config.rs
+++ b/app/tests/cli/local_config.rs
@@ -1,6 +1,6 @@
 use app::cli::local_config::{
-  ClientConfig, DefaultEnvironment, ResolvedServer, ServerSource, clear_default_environment, read,
-  save_default_environment,
+  ClientConfig, DefaultEnvironment, ResolvedServer, ServerSource, clear_default_environment,
+  normalize, read, save_default_environment,
 };
 use tempfile::TempDir;
 
@@ -89,4 +89,29 @@ fn old_configuration_without_a_default_still_loads() {
   let config: ClientConfig =
     toml::from_str("version = 1\nserver_url = 'http://localhost:8840'\n").unwrap();
   assert!(config.default_environment.is_none());
+}
+
+#[test]
+fn server_urls_require_https_except_on_loopback() {
+  for url in [
+    "https://dopbase.example.com",
+    "http://localhost:8840",
+    "http://127.0.0.42:8840",
+    "http://[::1]:8840",
+  ] {
+    assert!(normalize(url).is_ok(), "expected {url} to be accepted");
+  }
+
+  for url in [
+    "http://dopbase.example.com",
+    "http://192.168.1.10:8840",
+    "http://localhost.example.com:8840",
+    "http://[2001:db8::1]:8840",
+  ] {
+    let error = normalize(url).unwrap_err().to_string();
+    assert!(
+      error.contains("remote URLs must use HTTPS"),
+      "{url}: {error}"
+    );
+  }
 }

--- a/app/tests/config.rs
+++ b/app/tests/config.rs
@@ -200,6 +200,49 @@ fn remote_host_without_public_url_fails_with_guidance() {
 }
 
 #[test]
+fn explicit_public_urls_require_https_except_on_loopback() {
+  for public_url in [
+    "https://dopbase.example.com",
+    "http://localhost:8840",
+    "http://127.0.0.9:8840",
+    "http://[::1]:8840",
+  ] {
+    let directory = tempfile::TempDir::new().unwrap();
+    let config = ServerConfig::load_with_environment(
+      &ServerOverrides {
+        data_dir: Some(directory.path().join("data")),
+        public_url: Some(public_url.into()),
+        ..Default::default()
+      },
+      EnvironmentOverrides::default(),
+    );
+    assert!(config.is_ok(), "expected {public_url} to be accepted");
+  }
+
+  for public_url in [
+    "http://dopbase.example.com",
+    "http://10.0.0.8:8840",
+    "http://localhost.example.com:8840",
+  ] {
+    let directory = tempfile::TempDir::new().unwrap();
+    let error = ServerConfig::load_with_environment(
+      &ServerOverrides {
+        data_dir: Some(directory.path().join("data")),
+        public_url: Some(public_url.into()),
+        ..Default::default()
+      },
+      EnvironmentOverrides::default(),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(
+      error.contains("remote URLs must use HTTPS"),
+      "{public_url}: {error}"
+    );
+  }
+}
+
+#[test]
 fn localhost_host_maps_to_loopback() {
   let directory = tempfile::TempDir::new().unwrap();
   let data_dir = directory.path().join("data");

--- a/app/tests/services/crypto.rs
+++ b/app/tests/services/crypto.rs
@@ -3,6 +3,21 @@ use std::fs;
 use app::services::crypto::{CryptoService, EncryptedValue, parse_master_key, rekey_database};
 use app::services::db::DbClient;
 
+fn random_key() -> Vec<u8> {
+  let mut key = vec![0_u8; 32];
+  getrandom::fill(&mut key).unwrap();
+  key
+}
+
+fn distinct_keys() -> (Vec<u8>, Vec<u8>) {
+  let first = random_key();
+  let mut second = random_key();
+  while first == second {
+    second = random_key();
+  }
+  (first, second)
+}
+
 #[tokio::test]
 async fn round_trip_detects_tampering_and_wrong_master_key() {
   let directory = tempfile::TempDir::new().unwrap();
@@ -30,7 +45,7 @@ async fn round_trip_detects_tampering_and_wrong_master_key() {
       .is_err()
   );
 
-  fs::write(&key, [7_u8; 32]).unwrap();
+  fs::write(&key, random_key()).unwrap();
   assert!(CryptoService::initialize(db.pool(), &key).await.is_err());
   db.close().await;
 }
@@ -56,7 +71,7 @@ async fn generated_key_is_owner_only() {
 
 #[test]
 fn parses_raw_and_hex_master_keys() {
-  let raw = vec![0x42_u8; 32];
+  let raw = random_key();
   assert_eq!(parse_master_key(&raw).unwrap(), raw);
 
   let hex = hex::encode(&raw);
@@ -74,8 +89,8 @@ fn parses_raw_and_hex_master_keys() {
 
 #[test]
 fn cross_key_backup_decryption_requires_the_source_key() {
-  let source_key = vec![0x11_u8; 32];
-  let target_crypto = CryptoService::from_key(vec![0x22_u8; 32]);
+  let (source_key, target_key) = distinct_keys();
+  let target_crypto = CryptoService::from_key(target_key);
   let source_crypto = CryptoService::from_key(source_key.clone());
   let payload = b"secret-dopbase-backup-payload-content";
   let encrypted = source_crypto.encrypt_backup(payload).unwrap();
@@ -121,8 +136,7 @@ async fn rekey_database_preserves_values_and_swaps_keys() {
   .await
   .unwrap();
 
-  let old_key = vec![0x11_u8; 32];
-  let new_key = vec![0x22_u8; 32];
+  let (old_key, new_key) = distinct_keys();
   let old_crypto = CryptoService::from_key(old_key.clone());
   let new_crypto = CryptoService::from_key(new_key.clone());
   let (verification_ciphertext, verification_nonce) = old_crypto

--- a/docs/cli/client-connect.md
+++ b/docs/cli/client-connect.md
@@ -33,6 +33,10 @@ The command normalizes the URL and verifies that it is a compatible Dopbase
 server before changing machine-global state. If validation fails, the previous
 server and credential remain active.
 
+Remote servers must use HTTPS. Plain HTTP is accepted only for `localhost` and
+loopback IP addresses such as `127.0.0.1` and `::1`. The client does not follow
+redirects, so the configured endpoint must be the final Dopbase URL.
+
 An actual server change requires a yes/no confirmation. The warning identifies
 the current and destination endpoints and explains that Dopbase will stop the
 current managed background server when present, delete the encrypted local CLI

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -62,9 +62,10 @@ Select a self-hosted or Cloud endpoint with:
 dopbase client connect https://dopbase.example.com
 ```
 
-`connect` accepts an absolute HTTP or HTTPS URL. It normalizes the endpoint,
+`connect` accepts an absolute URL. Remote endpoints must use HTTPS; HTTP is
+limited to `localhost` and loopback IP addresses. Dopbase normalizes the URL,
 rejects embedded credentials, query strings, and fragments, then verifies that
-the endpoint is a compatible Dopbase server. The new server is saved only after
+the endpoint is a compatible server. The new server is saved only after
 validation succeeds. A failed connection leaves the previous configuration and
 credential unchanged.
 
@@ -102,6 +103,9 @@ written to `config.toml` or a Dopbase server's SQLite database.
 The encrypted payload also caches the normalized administrator email so
 `dopbase status` can identify the login without contacting the server. Older
 sessions remain valid but show an unknown email until the next login.
+
+Remote server URLs must use HTTPS. HTTP is limited to `localhost` and loopback
+IP addresses, and the client does not follow redirects.
 
 Only one saved connection is active in v0.1.0. Logging in again replaces the
 credential for that server. `dopbase logout` removes the active credential but

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -62,7 +62,7 @@ Select a self-hosted or Cloud endpoint with:
 dopbase client connect https://dopbase.example.com
 ```
 
-`connect` accepts an absolute URL. Remote endpoints must use HTTPS; HTTP is
+`connect` accepts an absolute URL. Remote endpoints must use HTTPS, HTTP is
 limited to `localhost` and loopback IP addresses. Dopbase normalizes the URL,
 rejects embedded credentials, query strings, and fragments, then verifies that
 the endpoint is a compatible server. The new server is saved only after

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -80,8 +80,9 @@ By default, all runtime files live in `~/.dopbase`. Select another directory
 with the global `--data-dir <dir>` option or `DOPBASE_DATA_DIR`. Data-directory
 selection resolves in this order: CLI option, environment variable, default.
 
-`public_url` is required when binding beyond loopback. Dopbase does not trust
-forwarded headers, and TLS termination remains an operator concern.
+`public_url` is required when binding beyond loopback and must use HTTPS.
+HTTP is accepted only for `localhost` and loopback IP addresses. Dopbase does
+not trust forwarded headers, and TLS termination remains an operator concern.
 
 ## API documentation
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:installer:windows": "pwsh -NoProfile -File scripts/install.test.ps1",
     "preview": "vite preview",
     "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs && bun ./scripts/docs-postbuild.mjs",
+    "docs:build": "rm -rf build && vitepress build docs && bun ./scripts/docs-postbuild.mjs",
     "docs:test:mermaid": "bun scripts/check-mermaid-viewer.mjs",
     "docs:preview": "vitepress preview docs"
   },


### PR DESCRIPTION
## Summary

- Require HTTPS for remote client and public server URLs. HTTP remains available for localhost and loopback IP addresses.
- Disable HTTP redirects and validate the endpoint again when constructing the API client.
- Replace fixed cryptographic test keys with randomly generated key material.
- Reuse the strict backup-key sanitizer during bootstrap restore and add traversal boundary tests.
- Rename the recent-authentication helper so CodeQL does not misclassify the returned client as password data.

## CodeQL result

The pull request scan completed with zero findings in Rust, JavaScript/TypeScript, and Actions. The latest main-branch Rust analysis reports 30 results at ff27714; the pull request Rust analysis reports 0 results at 11ce6ea.

- Alerts #28 and #29 are resolved through transport enforcement, redirect rejection, and the helper rename.
- Alert #30 is resolved by removing hard-coded cryptographic keys from the test.
- Alerts #1 through #27 no longer appear in the fresh scan. Regression tests now enforce the path boundary, and bootstrap restore uses the shared strict filename sanitizer.

No alerts were dismissed manually.

## Compatibility

Existing remote HTTP endpoints must move to HTTPS. Local development on localhost, 127.0.0.0/8, and ::1 continues to support HTTP. Redirecting endpoints must be configured using their final URL.

## Verification

- cargo fmt --manifest-path app/Cargo.toml -- --check
- cargo clippy --manifest-path app/Cargo.toml --locked --all-targets --all-features -- -D warnings
- cargo test --manifest-path app/Cargo.toml --locked --all-targets
- cargo test --manifest-path app/Cargo.toml --locked --all-targets --all-features
- bun run build
- bun run docs:build