### PR TITLE
fix(security): harden password verification and destructive flows

### DIFF
--- a/app/src/modules/auth/service.rs
+++ b/app/src/modules/auth/service.rs
@@ -192,15 +192,27 @@ pub async fn reauthenticate(
   password: &str,
 ) -> Result<(), HttpError> {
   let (admin_id, email) = require_project_manager(identity)?;
+  // Password re-verification is brute-forceable through a hijacked session,
+  // so it shares the login limiter's budget for this account.
+  let limit_key = format!("password_verify:{admin_id}");
+  if !state.rate_limiter.check(&limit_key).await {
+    return Err(HttpError::new(
+      axum::http::StatusCode::TOO_MANY_REQUESTS,
+      RATE_LIMITED,
+      "Too many attempts. Please try again later.",
+    ));
+  }
   let hash = repository::password_hash(state.db.pool(), admin_id)
     .await?
     .ok_or_else(|| HttpError::unauthorized(AUTHENTICATION_INVALID, "The session is invalid."))?;
   if !common::verify_password_async(password.to_owned(), hash).await? {
+    state.rate_limiter.failure(&limit_key).await;
     return Err(HttpError::unauthorized(
       AUTHENTICATION_INVALID,
       "The password is incorrect.",
     ));
   }
+  state.rate_limiter.clear(&limit_key).await;
   let session_id = match identity {
     AuthIdentity::Admin { session_id, .. } => session_id,
     _ => unreachable!(),
@@ -233,16 +245,28 @@ pub async fn change_password(
   request: ChangePasswordRequest,
 ) -> Result<(), HttpError> {
   let (admin_id, email) = require_project_manager(identity)?;
+  // Verifying the current password is the same brute-force surface as
+  // reauthentication, so it shares that limiter budget.
+  let limit_key = format!("password_verify:{admin_id}");
+  if !state.rate_limiter.check(&limit_key).await {
+    return Err(HttpError::new(
+      axum::http::StatusCode::TOO_MANY_REQUESTS,
+      RATE_LIMITED,
+      "Too many attempts. Please try again later.",
+    ));
+  }
   common::validate_password(&request.new_password)?;
   let old = repository::password_hash(state.db.pool(), admin_id)
     .await?
     .ok_or_else(|| HttpError::unauthorized(AUTHENTICATION_INVALID, "The session is invalid."))?;
   if !common::verify_password_async(request.current_password.clone(), old).await? {
+    state.rate_limiter.failure(&limit_key).await;
     return Err(HttpError::unauthorized(
       AUTHENTICATION_INVALID,
       "The password is incorrect.",
     ));
   }
+  state.rate_limiter.clear(&limit_key).await;
   let new_hash = common::hash_password_async(request.new_password.clone()).await?;
   let mut tx = state.db.pool().begin().await?;
   sqlx::query("UPDATE admins SET password_hash=?,updated_at=? WHERE id=?")

--- a/app/src/modules/backups/service.rs
+++ b/app/src/modules/backups/service.rs
@@ -794,6 +794,18 @@ pub async fn restore_database_from_archive(
     HttpError::internal()
   })?;
 
+  // Best-effort scrub: the wiped rows must not linger in the live database
+  // file or WAL after the restore replaced them.
+  if let Err(error) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+    .execute(state.db.pool())
+    .await
+  {
+    tracing::warn!(%error, "failed to checkpoint WAL after backup restore");
+  }
+  if let Err(error) = sqlx::query("VACUUM").execute(state.db.pool()).await {
+    tracing::warn!(%error, "failed to vacuum after backup restore");
+  }
+
   // Run migrations on restored database if needed
   Ok(())
 }

--- a/app/src/modules/instance/service.rs
+++ b/app/src/modules/instance/service.rs
@@ -1,5 +1,6 @@
 use super::{model::InstanceStatus, repository};
 use crate::{
+  constants::errors::RATE_LIMITED,
   extractors::{
     require_admin, require_metadata_access, require_mutation, require_recent_browser_auth,
     require_root_browser,
@@ -123,6 +124,16 @@ pub async fn factory_reset(
   require_mutation(identity, headers)?;
   require_recent_browser_auth(identity)?;
   let (root_id, _) = require_root_browser(identity)?;
+  // The root password verification here shares the reauthentication
+  // limiter budget for this account.
+  let limit_key = format!("password_verify:{root_id}");
+  if !state.rate_limiter.check(&limit_key).await {
+    return Err(HttpError::new(
+      axum::http::StatusCode::TOO_MANY_REQUESTS,
+      RATE_LIMITED,
+      "Too many attempts. Please try again later.",
+    ));
+  }
   if request.confirmation != "FACTORY RESET" || !request.acknowledged {
     return Err(HttpError::bad_request(
       "RESET_CONFIRMATION_REQUIRED",
@@ -134,11 +145,13 @@ pub async fn factory_reset(
     .fetch_one(state.db.pool())
     .await?;
   if !crate::modules::common::verify_password_async(request.current_password, hash).await? {
+    state.rate_limiter.failure(&limit_key).await;
     return Err(HttpError::unauthorized(
       "AUTHENTICATION_INVALID",
       "The root password is incorrect.",
     ));
   }
+  state.rate_limiter.clear(&limit_key).await;
   if state
     .maintenance
     .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -169,6 +182,17 @@ pub async fn factory_reset(
         .await?;
     }
     tx.commit().await?;
+    // Best-effort scrub: deleted secret ciphertext must not linger in the
+    // database file or WAL after a reset.
+    if let Err(error) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+      .execute(state.db.pool())
+      .await
+    {
+      tracing::warn!(%error, "failed to checkpoint WAL after factory reset");
+    }
+    if let Err(error) = sqlx::query("VACUUM").execute(state.db.pool()).await {
+      tracing::warn!(%error, "failed to vacuum after factory reset");
+    }
     let backup_dir = state.config.data_dir.join("backups");
     if let Ok(entries) = std::fs::read_dir(&backup_dir) {
       for entry in entries.flatten() {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>dopbase</title>
+    <title>Dopbase Console</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/pages/Login/Login.controller.test.ts
+++ b/src/pages/Login/Login.controller.test.ts
@@ -59,6 +59,45 @@ describe("useLoginController", () => {
     expect(store.isAuthenticated).toBe(true);
   });
 
+  it("routes to a safe internal redirect target after sign-in", async () => {
+    routeQuery.redirect = "/workspace/p/acme/e/env_1";
+    vi.mocked(authApi.login).mockResolvedValueOnce({
+      adminId: "usr_1",
+      email: "a@b.c",
+      sessionKind: "browser",
+      token: null,
+      csrfToken: "csrf_1",
+    });
+    const c = useLoginController();
+    c.email.value = "a@b.c";
+    c.password.value = "pw";
+    await c.submit();
+    expect(routerPush).toHaveBeenCalledWith("/workspace/p/acme/e/env_1");
+  });
+
+  it("ignores cross-origin and protocol-relative redirect targets", async () => {
+    vi.mocked(authApi.login).mockResolvedValue({
+      adminId: "usr_1",
+      email: "a@b.c",
+      sessionKind: "browser",
+      token: null,
+      csrfToken: "csrf_1",
+    });
+    for (const redirect of [
+      "https://evil.example.test/phish",
+      "//evil.example.test/phish",
+      "javascript:alert(1)",
+    ]) {
+      routerPush.mockReset();
+      routeQuery.redirect = redirect;
+      const c = useLoginController();
+      c.email.value = "a@b.c";
+      c.password.value = "pw";
+      await c.submit();
+      expect(routerPush).toHaveBeenCalledWith({ name: "workspace" });
+    }
+  });
+
   it("honors the redirect query after login", async () => {
     vi.mocked(authApi.login).mockResolvedValueOnce({
       adminId: "usr_1",

--- a/src/pages/Login/Login.controller.ts
+++ b/src/pages/Login/Login.controller.ts
@@ -2,7 +2,7 @@ import { ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { ApiError } from "~/services/http.client";
 import { useAuthStore } from "~/stores/auth.store";
-import { isValidEmail } from "~/utils/validation";
+import { isSafeRedirect, isValidEmail } from "~/utils/validation";
 
 /**
  * Login screen controller: form state, client-side validation, stable
@@ -60,7 +60,9 @@ export function useLoginController() {
       await auth.login(email.value.trim().toLowerCase(), password.value);
       const redirect = route.query.redirect;
       router.push(
-        typeof redirect === "string" ? redirect : { name: "workspace" },
+        typeof redirect === "string" && isSafeRedirect(redirect)
+          ? redirect
+          : { name: "workspace" },
       );
     } catch (error) {
       mapApiError(error);

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isSafeRedirect,
   isValidEmail,
   isValidSecretKey,
   validatePasswordLength,
@@ -9,6 +10,15 @@ describe("shared validation", () => {
   it("accepts bounded email addresses and trims input", () => {
     expect(isValidEmail(" admin@example.com ")).toBe(true);
     expect(isValidEmail("admin@example")).toBe(false);
+  });
+
+  it("accepts only same-origin paths as redirect targets", () => {
+    expect(isSafeRedirect("/workspace")).toBe(true);
+    expect(isSafeRedirect("/workspace/p/acme/e/env_1")).toBe(true);
+    expect(isSafeRedirect("https://evil.example.test/phish")).toBe(false);
+    expect(isSafeRedirect("//evil.example.test/phish")).toBe(false);
+    expect(isSafeRedirect("javascript:alert(1)")).toBe(false);
+    expect(isSafeRedirect("workspace")).toBe(false);
   });
 
   it("counts password characters consistently with the server", () => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -31,3 +31,14 @@ export function isValidSecretKey(value: string): boolean {
     SECRET_KEY_PATTERN.test(value)
   );
 }
+
+/**
+ * Only same-origin, non-protocol-relative paths may be used as post-login
+ * redirect targets. Blocks absolute URLs (`https://…`) and protocol-relative
+ * shortcuts (`//host`).
+ */
+export function isSafeRedirect(value: string): boolean {
+  return (
+    value.startsWith("/") && !value.startsWith("//") && !value.includes("://")
+  );
+}


### PR DESCRIPTION
## Summary

This PR addresses findings from the 2026-09-08 internal security audit.

- Rate-limit password re-verification for reauthentication, password changes, and factory reset, using a shared per-account budget.
- Clear the limiter after successful verification and record failed attempts.
- Checkpoint the SQLite WAL and vacuum the database after restores and factory resets so deleted secret data is not left in the live database file or WAL.
- Validate post-login redirect targets so only same-origin paths are accepted.
- Add regression coverage for redirect validation and safe login routing.
- Update the console page title to `Dopbase Console`.

## Testing

- `cargo test --manifest-path app/Cargo.toml` passed.
- Targeted Vitest tests were attempted, but the sandbox blocked Vitest from creating its temporary directory.