### PR TITLE
feat: add CLI short flags and refine startup output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Admin UI, API documentation, and public guides.
 
 ### Improvement
 
+- `dopbase run -t <TOKEN>` is now a short form of `--token <TOKEN>`.
+- `dopbase -v` now prints the installed version as `v<version>`. The existing
+  `-V` and `--version` flags use the same output.
 - CLI errors, prompts, and help text provide clearer recovery steps and use
   consistent terms.
 - Frontend copy, OpenAPI descriptions, source comments, and public

--- a/app/src/cli/args.rs
+++ b/app/src/cli/args.rs
@@ -1,6 +1,7 @@
-use clap::{Args, Parser, Subcommand, error::ErrorKind};
+use clap::{ArgAction, Args, Parser, Subcommand, error::ErrorKind};
 use std::{
   ffi::{OsStr, OsString},
+  io::{self, Write},
   path::PathBuf,
 };
 
@@ -10,12 +11,21 @@ use crate::constants::help::*;
 #[command(
   name = "dopbase",
   version,
+  disable_version_flag = true,
   about = "Secrets management in one binary",
   long_about = "Dopbase keeps application secrets in one binary: run a server, store \
 secrets per project and environment, and inject them into any command with `run`.",
   after_help = AFTER_HELP
 )]
 pub struct Cli {
+  /// Print the installed Dopbase version.
+  #[arg(
+    short = 'v',
+    visible_short_alias = 'V',
+    long = "version",
+    action = ArgAction::Version
+  )]
+  version: Option<bool>,
   /// Client endpoint for this invocation, overriding the saved server and
   /// DOPBASE_URL. This does not apply to local server commands.
   #[arg(long, global = true, value_name = "URL")]
@@ -61,6 +71,7 @@ impl Cli {
     let arguments = std::env::args_os().collect::<Vec<_>>();
     match Self::try_parse_from(arguments.clone()) {
       Ok(cli) => cli,
+      Err(error) if error.kind() == ErrorKind::DisplayVersion => Self::exit_with_version(),
       Err(error)
         if matches!(
           error.kind(),
@@ -76,6 +87,15 @@ impl Cli {
       }
       Err(error) => error.exit(),
     }
+  }
+
+  fn exit_with_version() -> ! {
+    let mut stdout = io::stdout().lock();
+    if let Err(write_error) = writeln!(stdout, "v{}", env!("CARGO_PKG_VERSION")) {
+      clap::Error::raw(ErrorKind::Io, write_error).exit();
+    }
+    drop(stdout);
+    std::process::exit(0)
   }
 }
 
@@ -204,7 +224,7 @@ pub enum Command {
     #[arg(help = ENVIRONMENT_ARG_HELP)]
     environment: Option<String>,
     /// Runner token for this invocation. Overrides DOPBASE_TOKEN and the saved credential.
-    #[arg(long, value_name = "TOKEN")]
+    #[arg(short = 't', long, value_name = "TOKEN")]
     token: Option<String>,
     /// Command to run with the injected secrets.
     #[arg(last = true, required = true)]

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -344,7 +344,7 @@ impl ServerConfig {
   pub fn inferred_public_url_warning(&self) -> Option<String> {
     (self.public_url_source == PublicUrlSource::NetworkInferred).then(|| {
       format!(
-        "No public URL is configured. Using {}. This HTTP URL does not encrypt credentials or secrets and may be wrong behind a proxy or NAT. Set --public-url, DOPBASE_PUBLIC_URL, or public_url in server.toml.",
+        "No public URL is configured. Using {}.\nSet --public-url, DOPBASE_PUBLIC_URL, or public_url in server.toml.\nThis HTTP URL does not encrypt credentials or secrets.",
         self.public_url
       )
     })

--- a/app/src/constants/help.rs
+++ b/app/src/constants/help.rs
@@ -164,6 +164,7 @@ Examples:
   dopbase run -- npm run dev
   dopbase run env_482731 -- npm run dev
   dopbase run payment-service/development -- npm run dev
+  dopbase run payment-service/production -t dbs_xxx -- npm start
   dopbase run payment-service/production --token dbs_xxx -- npm start
 ";
 

--- a/app/src/daemon.rs
+++ b/app/src/daemon.rs
@@ -247,13 +247,13 @@ pub(crate) async fn start(
   drop(_lock);
   let started = spawn(&data_dir, flags).await?;
   if !json_output {
-    eprintln!(
+    anstream::eprintln!(
       "\n{}\n",
       crate::server::startup_banner(&config.public_url, &data_dir, config.docs_enabled,)
     );
   }
   if let Some(warning) = config.inferred_public_url_warning() {
-    eprintln!("Warning: {warning}\n");
+    anstream::eprintln!("{}\n", crate::server::startup_warning(&warning));
   }
   if let Some(token) = &started.setup_token {
     eprintln!(

--- a/app/src/server.rs
+++ b/app/src/server.rs
@@ -4,6 +4,7 @@ use std::{
   time::Duration,
 };
 
+use anstyle::{AnsiColor, Color, Effects, Style};
 use anyhow::{Context, Result};
 use axum::{
   Router,
@@ -207,8 +208,9 @@ pub fn startup_banner(
   docs_enabled: bool,
 ) -> String {
   let public_url = public_url.trim_end_matches('/');
+  let heading = Style::new().effects(Effects::BOLD);
   let mut rows = vec![
-    "Dopbase".to_string(),
+    format!("{heading}Dopbase{heading:#}"),
     "Secure, Simple and Private".to_string(),
     format!("Version {}", env!("CARGO_PKG_VERSION")),
     String::new(),
@@ -220,6 +222,13 @@ pub fn startup_banner(
     rows.push(format!("API Specs:  {public_url}/api/docs"));
   }
   rows.join("\n")
+}
+
+pub fn startup_warning(warning: &str) -> String {
+  let style = Style::new()
+    .fg_color(Some(Color::Ansi(AnsiColor::Yellow)))
+    .effects(Effects::BOLD);
+  format!("{style}Warning: {style:#}{warning}")
 }
 
 /// Formats the one-time setup token message shown on first run, including a
@@ -265,7 +274,7 @@ pub async fn serve_with_ready(
     ready.ok(std::process::id(), setup_token.as_deref());
   }
   let public_url = state.config.public_url.trim_end_matches('/');
-  eprintln!(
+  anstream::eprintln!(
     "\n{}\n",
     startup_banner(
       public_url,
@@ -274,7 +283,7 @@ pub async fn serve_with_ready(
     )
   );
   if let Some(warning) = state.config.inferred_public_url_warning() {
-    eprintln!("Warning: {warning}\n");
+    anstream::eprintln!("{}\n", startup_warning(&warning));
   }
   if let Some(setup) = setup_token.as_deref() {
     eprintln!("{}", setup_token_message(public_url, setup));

--- a/app/tests/cli/args.rs
+++ b/app/tests/cli/args.rs
@@ -126,6 +126,15 @@ fn parses_every_v0_1_command_shape() {
       "--",
       "printenv",
     ],
+    &[
+      "dopbase",
+      "run",
+      "env_482731",
+      "-t",
+      "dbs_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      "--",
+      "printenv",
+    ],
     &["dopbase", "admin", "reset-password", "admin@example.com"],
     &["dopbase", "admin", "factory-reset"],
     &["dopbase", "admin", "factory-reset", "--no-backup"],
@@ -187,6 +196,49 @@ fn run_token_must_appear_before_the_child_command_separator() {
     Some("dbs_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
   );
   assert_eq!(command, ["printenv", "--token", "child-value"]);
+}
+
+#[test]
+fn run_accepts_the_short_token_flag() {
+  let cli = Cli::try_parse_from([
+    "dopbase",
+    "run",
+    "env_482731",
+    "-t",
+    "dbs_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "--",
+    "printenv",
+    "-t",
+    "child-value",
+  ])
+  .unwrap();
+  let Command::Run { token, command, .. } = cli.command else {
+    panic!("expected run command");
+  };
+  assert_eq!(
+    token.as_deref(),
+    Some("dbs_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+  );
+  assert_eq!(command, ["printenv", "-t", "child-value"]);
+}
+
+#[test]
+fn login_does_not_accept_the_short_token_flag() {
+  assert!(Cli::try_parse_from(["dopbase", "login", "-t"]).is_err());
+}
+
+#[test]
+fn version_flags_print_only_the_prefixed_version() {
+  let expected = format!("v{}\n", env!("CARGO_PKG_VERSION"));
+  for flag in ["-v", "-V", "--version"] {
+    let output = ProcessCommand::new(env!("CARGO_BIN_EXE_dopbase"))
+      .arg(flag)
+      .output()
+      .unwrap();
+    assert!(output.status.success(), "{flag}: {output:?}");
+    assert_eq!(output.stdout, expected.as_bytes(), "{flag}");
+    assert!(output.stderr.is_empty(), "{flag}: {output:?}");
+  }
 }
 
 #[test]
@@ -334,7 +386,18 @@ fn rejects_conflicting_file_options() {
 
 #[test]
 fn top_level_help_lists_common_server_options() {
-  let help = Cli::command().render_long_help().to_string();
+  let mut command = Cli::command();
+  let version = command
+    .get_arguments()
+    .find(|argument| argument.get_long() == Some("version"))
+    .unwrap();
+  assert_eq!(version.get_short(), Some('v'));
+  assert!(
+    version
+      .get_visible_short_aliases()
+      .is_some_and(|aliases| aliases.contains(&'V'))
+  );
+  let help = command.render_long_help().to_string();
   assert!(help.contains("Common server options:"), "{help}");
   assert!(help.contains("--host <HOST>"), "{help}");
   assert!(help.contains("--port <PORT>"), "{help}");

--- a/docs/cli/cheat-sheet.md
+++ b/docs/cli/cheat-sheet.md
@@ -20,7 +20,7 @@ option when it does not apply, such as `--server` with a local server command.
 | `--data-dir <DIR>` | Use another directory for Dopbase state and configuration                           | `dopbase --data-dir /srv/dopbase server status`             |
 | `--json`           | Print machine-readable JSON where the command supports it                           | `dopbase --json project list`                               |
 | `-h`, `--help`     | Show help for the current command                                                   | `dopbase secret set --help`                                 |
-| `-V`, `--version`  | Show the installed Dopbase version                                                  | `dopbase --version`                                         |
+| `-v`, `-V`, `--version` | Show the installed Dopbase version                                             | `dopbase -v`                                                |
 
 The built-in help command accepts the same command path. For example,
 `dopbase help secret set` shows the usage, argument descriptions, options, and
@@ -75,7 +75,7 @@ examples for `secret set`.
 | Import a dotenv file      | `dopbase import <ENVIRONMENT> <FILE>`          | `--dry-run` previews changes. `--replace` removes remote keys absent from the file. `--yes` skips confirmation | `dopbase import payment-service/staging .env.staging --dry-run`                           |
 | Export to a file          | `dopbase export <ENVIRONMENT> --output <FILE>` | `--output <FILE>` or `--stdout` is required. `--force` overwrites an existing file                             | `dopbase export payment-service/staging --output .env.staging --force`                    |
 | Export to standard output | `dopbase export <ENVIRONMENT> --stdout`        | `--stdout` conflicts with `--output`                                                                           | `dopbase export payment-service/staging --stdout`                                         |
-| Run with injected secrets | `dopbase run [ENVIRONMENT] -- <COMMAND>`       | `--token <TOKEN>` overrides other credentials. Everything after `--` is the child command                      | `dopbase run payment-service/development -- npm start`                                    |
+| Run with injected secrets | `dopbase run [ENVIRONMENT] -- <COMMAND>`       | `-t <TOKEN>` or `--token <TOKEN>` overrides other credentials. Everything after `--` is the child command      | `dopbase run payment-service/development -- npm start`                                    |
 
 ## Tokens, backups, and maintenance
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -91,11 +91,11 @@ The server resolution order is:
 
 Machine runners can register a credential with `dopbase login --token`. CI
 systems and deployment platforms can use `DOPBASE_TOKEN`. For `dopbase run`, an
-explicit `--token <TOKEN>` takes precedence over `DOPBASE_TOKEN`, which takes
-precedence over the encrypted credential saved by `login`. A saved credential
-is used only when it matches the resolved server. Command-line tokens may be
-visible in shell history and process inspection, so they are best kept for
-one-off overrides.
+explicit `-t <TOKEN>` or `--token <TOKEN>` takes precedence over
+`DOPBASE_TOKEN`, followed by the encrypted credential saved by `login`. A saved
+credential is used only when it matches the resolved server. Command-line
+tokens may be visible in shell history and process inspection, so they are best
+kept for one-off overrides.
 
 `dopbase client status` displays the config path, resolved server and its source,
 authentication source, locally identified credential type, login email, and
@@ -276,7 +276,7 @@ dopbase run payment-service/production -- npm start
 Use an explicit token only for a one-off command:
 
 ```bash
-dopbase run payment-service/production --token "$RUNNER_TOKEN" -- npm start
+dopbase run payment-service/production -t "$RUNNER_TOKEN" -- npm start
 ```
 
 Automation may set `DOPBASE_ENV` instead:

--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -192,7 +192,7 @@ The effective server is resolved in this order:
 
 Authentication is resolved in this order:
 
-1. `--token <TOKEN>` on `dopbase run`
+1. `-t <TOKEN>` or `--token <TOKEN>` on `dopbase run`
 2. `DOPBASE_TOKEN`
 3. The encrypted credential matching the normalized active server
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -31,7 +31,7 @@ Add the reported installation directory to `PATH` if the installer asks you
 to, then confirm the installation:
 
 ```bash
-dopbase --version
+dopbase -v
 ```
 
 Set `DOPBASE_INSTALL_DIR` to choose another directory and

--- a/docs/guide/run-an-application.md
+++ b/docs/guide/run-an-application.md
@@ -40,10 +40,10 @@ human login or runner token replaces it. CI systems can set `DOPBASE_TOKEN`
 instead. For a one-off override, use:
 
 ```bash
-dopbase run env_482731 --token "$RUNNER_TOKEN" -- ./payment-service
+dopbase run env_482731 -t "$RUNNER_TOKEN" -- ./payment-service
 ```
 
-Credential priority is `--token`, then `DOPBASE_TOKEN`, then the saved
+Credential priority is `-t` or `--token`, then `DOPBASE_TOKEN`, then the saved
 credential. Command-line tokens may appear in shell history or process
 inspection, so prefer a saved token for a long-running server.
 

--- a/docs/reference/identity.md
+++ b/docs/reference/identity.md
@@ -37,9 +37,9 @@ The prompt does not echo the token. A provisioning script can pipe it instead:
 printf '%s' "$RUNNER_TOKEN" | dopbase login --token
 ```
 
-For one run, pass `--token <TOKEN>` before the child-command separator. CI and
-deployment platforms can set `DOPBASE_TOKEN`. Authentication uses the command
-flag first, then `DOPBASE_TOKEN`, then the saved credential.
+For one run, pass `-t <TOKEN>` or `--token <TOKEN>` before the child-command
+separator. CI and deployment platforms can set `DOPBASE_TOKEN`. Authentication
+uses the command flag first, then `DOPBASE_TOKEN`, then the saved credential.
 
 `dopbase login` and `dopbase login --token` encrypt their credential in the
 extensionless `session` file under the Dopbase data directory. The separate

--- a/scripts/install.test.sh
+++ b/scripts/install.test.sh
@@ -29,7 +29,7 @@ printf '%s\n' \
   'esac' >"${mock_bin}/curl"
 chmod 755 "${mock_bin}/curl"
 
-printf '%s\n' '#!/bin/sh' 'printf "%s\\n" "dopbase 0.0.12"' >"${test_dir}/dopbase"
+printf '%s\n' '#!/bin/sh' 'printf "%s\\n" "v0.0.12"' >"${test_dir}/dopbase"
 chmod 755 "${test_dir}/dopbase"
 
 (cd "$test_dir" && zip -q "${release_dir}/dopbase_0.0.12_darwin_arm64.zip" dopbase)
@@ -55,7 +55,7 @@ TEST_REAL_CURL="$real_curl" \
   sh "${root_dir}/scripts/install.sh" >/dev/null
 
 test -x "${install_dir}/dopbase"
-test "$("${install_dir}/dopbase" --version)" = "dopbase 0.0.12"
+test "$("${install_dir}/dopbase" --version)" = "v0.0.12"
 
 PATH="${mock_bin}:${PATH}" \
 TEST_UNAME_S=Darwin \

--- a/src/components/app/OneTimeTokenDialog.vue
+++ b/src/components/app/OneTimeTokenDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { nextTick, ref, watch } from "vue";
-import { KeyIcon } from "~/assets/icons";
+import { InfoIcon } from "~/assets/icons";
 import { DbAlert, DbButton, DbCopyButton, DbModal } from "~/components/ui";
 
 const props = defineProps<{
@@ -48,7 +48,7 @@ function handleCopyError(): void {
         class="flex items-start gap-3 rounded-card border border-warn/30 bg-warn/10 p-3.5">
         <div
           class="flex h-8 w-8 shrink-0 items-center justify-center rounded-control border border-warn/30 bg-canvas/40 text-warn">
-          <KeyIcon class="h-4 w-4" />
+          <InfoIcon class="h-4 w-4" />
         </div>
         <p class="text-sm text-ink">
           Copy this token now. It is shown once and cannot be recovered.
@@ -57,11 +57,12 @@ function handleCopyError(): void {
       </div>
 
       <section
-        class="overflow-hidden rounded-card border border-accent/35 bg-canvas shadow-[inset_3px_0_0_0_var(--color-accent)]"
+        class="overflow-hidden rounded-card border border-accent/35 bg-canvas"
         aria-label="One-time token">
         <div
           class="flex items-center justify-between border-b border-line-soft px-4 py-2.5">
-          <span class="font-mono text-xs font-semibold uppercase tracking-[0.12em] text-accent-strong">
+          <span
+            class="font-mono text-xs font-semibold uppercase tracking-[0.12em] text-accent-strong">
             One-time token
           </span>
           <span class="text-xs text-ink-faint">plaintext</span>
@@ -79,13 +80,14 @@ function handleCopyError(): void {
           <DbCopyButton
             class="justify-center sm:self-stretch"
             :value="token"
-            label="Copy token"
+            label="Copy"
             @copied="handleCopied"
             @copy-error="handleCopyError" />
         </div>
       </section>
 
-      <div class="grid gap-2 rounded-control bg-raised px-3.5 py-3 text-sm sm:grid-cols-2">
+      <div
+        class="gap-2 rounded-control bg-raised px-3.5 py-3 text-sm grid-cols-2">
         <div class="min-w-0">
           <p class="text-xs text-ink-muted">Name</p>
           <p class="truncate font-mono text-xs text-ink-strong">{{ name }}</p>

--- a/src/pages/Workspace/components/SecretsPanel.vue
+++ b/src/pages/Workspace/components/SecretsPanel.vue
@@ -17,6 +17,7 @@ import {
   DbModal,
   DbSkeleton,
   DbTextarea,
+  DbCode,
 } from "~/components/ui";
 import {
   EyeIcon,


### PR DESCRIPTION
<!-- pr-template:summary -->

## Summary

- Add `-t` as a short form of `dopbase run --token`.
- Add `-v` as a version flag while keeping `-V` and `--version`, and print versions as `v<version>`.
- Update the CLI docs, changelog, and installer test for the new flags and output.
- Refine the server startup warning and one-time token dialog copy and layout.

<!-- pr-template:compatibility -->

## Compatibility

`dopbase -v`, `dopbase -V`, and `dopbase --version` now print `v<version>` instead of `dopbase <version>`. Scripts that parse the old output need to be updated.

No API or database changes are required.

<!-- pr-template:verification -->

## Verification

- `cargo test --manifest-path app/Cargo.toml --test cli` (87 passed)

<!-- pr-template:checklist -->

## Checklist

- [x] I kept this pull request focused on one problem.
- [x] I added or updated tests for behavior changes, or explained why tests are not needed.
- [x] I updated the documentation and `CHANGELOG.md` when public behavior changed, or explained why they are not needed.
- [x] I updated relevant documentation inside `/docs`