### PR TITLE
chore(release): prepare 0.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           version="${GITHUB_REF_NAME}"
           bind_address="127.0.0.1:${SMOKE_PORT}"
           public_url="http://${bind_address}"
-          test "$("${binary}" --version)" = "dopbase ${version}"
+          test "$("${binary}" --version)" = "v${version}"
 
           runtime_root="$(mktemp -d)"
           data_dir="${runtime_root}/data"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Dopbase are documented in this file.
 
-## Unreleased
+## 0.1.5 - 2026-09-11
 
 Dopbase now supports more self-hosted connection formats, creates a recovery
 archive before host-side factory resets, and uses clearer copy across the CLI,

--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "app"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "anstream",
  "anstyle",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.3"
+version = "0.1.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dopbase",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.5",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/src/components/app/OneTimeTokenDialog.test.ts
+++ b/src/components/app/OneTimeTokenDialog.test.ts
@@ -60,9 +60,10 @@ describe("OneTimeTokenDialog", () => {
     });
     mountDialog();
 
-    const copy = Array.from(document.querySelectorAll("button")).find(
-      (button) => button.textContent?.includes("Copy token"),
+    const copy = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy"]',
     );
+    expect(copy).not.toBeNull();
     copy?.click();
     await nextTick();
     await nextTick();


### PR DESCRIPTION
<!-- pr-template:summary -->

## Summary

Prepare Dopbase 0.1.5, publish its changelog notes, and align release checks with the current CLI version output and copy-button label.

<!-- pr-template:compatibility -->

## Compatibility

No compatibility impact.

<!-- pr-template:verification -->

## Verification

- `bun run test:github`
- `bunx vitest run --passWithNoTests`
- `bun run test:installer`
- `bun run build`
- `cargo fmt --manifest-path app/Cargo.toml -- --check`
- `cargo clippy --manifest-path app/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path app/Cargo.toml --locked --all-targets`
- `cargo test --manifest-path app/Cargo.toml --locked --all-targets --all-features`
- `cargo build --manifest-path app/Cargo.toml --locked --release`

<!-- pr-template:checklist -->

## Checklist

- [x] I kept this pull request focused on one problem.
- [x] I added or updated tests for behavior changes, or explained why tests are not needed.
- [x] I updated the documentation and `CHANGELOG.md` when public behavior changed, or explained why they are not needed.
- [x] I updated relevan documentation inside `/docs`