### PR TITLE
feat(cli): support JSON and YAML secret files

### DIFF
--- a/app/Cargo.lock
+++ b/app/Cargo.lock
@@ -43,6 +43,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +132,7 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "sha2 0.10.9",
  "sqlx",
@@ -160,6 +172,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "atoi"
@@ -688,6 +706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,7 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -900,6 +927,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48aa83cc6ac4dc610adf5501a5392b4bcc543b2c1f24eaf77469a96e31ec9abe"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1456,6 +1493,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,7 +1761,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2009,7 +2052,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2132,6 +2175,23 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afb591f9cdb6223c88ba39269aff895620c7f0716dc42b705b5733d5c7c0823"
+dependencies = [
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]
@@ -2604,10 +2664,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3212,7 +3272,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -49,6 +49,7 @@ inquire = "0.9"
 # Serialization for the REST API
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde-saphyr = "1.2"
 toml = "0.9"
 url = "2"
 # Authentication tokens

--- a/app/src/cli/args.rs
+++ b/app/src/cli/args.rs
@@ -5,7 +5,7 @@ use std::{
   path::PathBuf,
 };
 
-use crate::constants::help::*;
+use crate::{cli::secret_format::SecretFormat, constants::help::*};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -132,17 +132,18 @@ pub enum Command {
   #[command(after_help = STATUS_HELP)]
   Status,
   /// Create a project, its first environment, and import secrets.
-  ///
-  /// Bootstraps a new project on the server from an existing dotenv file.
   #[command(after_help = INIT_HELP)]
   Init {
     /// Name of the project to create (unique on the server).
     project: String,
     /// Name of the first environment to create (e.g. development).
     environment: String,
-    /// Dotenv file to import the initial secrets from.
+    /// Secret file to import, or - to read from stdin.
     #[arg(long, value_name = "FILE")]
     from: PathBuf,
+    /// Input format. Required for stdin; otherwise inferred from the filename.
+    #[arg(long, value_enum)]
+    format: Option<SecretFormat>,
   },
   /// Manage projects (create, list, show, rename, delete).
   #[command(after_help = PROJECT_HELP)]
@@ -162,7 +163,7 @@ pub enum Command {
     #[command(subcommand)]
     command: SecretCommand,
   },
-  /// Bulk-import secrets into an environment from a dotenv file.
+  /// Bulk-import secrets into an environment from a dotenv, JSON, or YAML source.
   ///
   /// Existing keys are kept unless --replace is passed. Use --dry-run to
   /// preview the result without changing anything.
@@ -170,8 +171,11 @@ pub enum Command {
   Import {
     #[arg(help = ENVIRONMENT_ARG_HELP)]
     environment: String,
-    /// Dotenv file to read secrets from.
+    /// Secret file to import, or - to read from stdin.
     path: PathBuf,
+    /// Input format. Required for stdin; otherwise inferred from the filename.
+    #[arg(long, value_enum)]
+    format: Option<SecretFormat>,
     /// Preview what would change without applying it.
     #[arg(long)]
     dry_run: bool,
@@ -182,7 +186,7 @@ pub enum Command {
     #[arg(long)]
     yes: bool,
   },
-  /// Export an environment's secrets to a dotenv file or stdout.
+  /// Export an environment's secrets as dotenv, JSON, or YAML.
   ///
   /// Requires --output <FILE> or --stdout. --force overwrites an existing
   /// file. Every export requires interactive password confirmation.
@@ -190,7 +194,7 @@ pub enum Command {
   Export {
     #[arg(help = ENVIRONMENT_ARG_HELP)]
     environment: String,
-    /// File to write the dotenv output to.
+    /// File to write. The format is inferred from its filename by default.
     #[arg(
       long,
       value_name = "FILE",
@@ -198,9 +202,12 @@ pub enum Command {
       required_unless_present = "stdout"
     )]
     output: Option<PathBuf>,
-    /// Print the dotenv output to stdout instead of a file.
+    /// Print plaintext secrets to stdout. Defaults to dotenv format.
     #[arg(long, conflicts_with = "output", required_unless_present = "output")]
     stdout: bool,
+    /// Output format. Overrides filename inference.
+    #[arg(long, value_enum)]
+    format: Option<SecretFormat>,
     /// Overwrite the output file if it already exists.
     #[arg(long)]
     force: bool,

--- a/app/src/cli/commands/export.rs
+++ b/app/src/cli/commands/export.rs
@@ -1,6 +1,6 @@
 use super::{environment, output};
 use crate::{
-  cli::{client, dotenv, local_config},
+  cli::{client, local_config, secret_format},
   constants::api,
   models::SecretInput,
 };
@@ -9,11 +9,14 @@ use reqwest::Method;
 use serde_json::{Value, json};
 use std::path::PathBuf;
 
+use secret_format::SecretFormat;
+
 pub(super) async fn execute(
   server: &local_config::ResolvedServer,
   reference: &str,
   output: Option<PathBuf>,
   stdout: bool,
+  format: Option<SecretFormat>,
   force: bool,
   json_output: bool,
 ) -> Result<i32> {
@@ -23,6 +26,7 @@ pub(super) async fn execute(
   if stdout && json_output {
     bail!("--stdout and --json cannot be combined");
   }
+  let format = SecretFormat::for_output(output.as_deref(), format);
   let api = client::recently_authenticated_client(server).await?;
   let env = environment::resolve_environment(&api, reference).await?;
   let data = api
@@ -33,7 +37,7 @@ pub(super) async fn execute(
     )
     .await?;
   let entries = parse_entries(&data)?;
-  let rendered = dotenv::render(&entries);
+  let rendered = secret_format::render(&entries, format)?;
   if stdout {
     print!("{rendered}");
   } else if let Some(path) = output {

--- a/app/src/cli/commands/import.rs
+++ b/app/src/cli/commands/import.rs
@@ -1,6 +1,6 @@
 use super::{environment, output, prompt};
 use crate::{
-  cli::{client, dotenv, local_config},
+  cli::{client, local_config, secret_format},
   constants::api,
 };
 use anyhow::Result;
@@ -8,19 +8,23 @@ use reqwest::Method;
 use serde_json::{Value, json};
 use std::path::Path;
 
+use secret_format::SecretFormat;
+
 pub(super) async fn execute(
   server: &local_config::ResolvedServer,
   reference: &str,
   path: &Path,
+  format: Option<SecretFormat>,
   dry_run: bool,
   replace: bool,
   yes: bool,
   json_output: bool,
 ) -> Result<i32> {
+  let format = SecretFormat::for_input(path, format)?;
   let api = client::human_client(server).await?;
   let env = environment::resolve_environment(&api, reference).await?;
   let id = environment::env_id(&env)?;
-  let entries = dotenv::parse_file(path)?;
+  let entries = secret_format::read(path, Some(format))?;
   let mode = if replace { "replace" } else { "merge" };
   let endpoint = api::secrets::import(id);
   let mut expected_revision = None;

--- a/app/src/cli/commands/import.rs
+++ b/app/src/cli/commands/import.rs
@@ -10,16 +10,28 @@ use std::path::Path;
 
 use secret_format::SecretFormat;
 
+pub(super) struct ImportOptions<'a> {
+  pub path: &'a Path,
+  pub format: Option<SecretFormat>,
+  pub dry_run: bool,
+  pub replace: bool,
+  pub yes: bool,
+  pub json_output: bool,
+}
+
 pub(super) async fn execute(
   server: &local_config::ResolvedServer,
   reference: &str,
-  path: &Path,
-  format: Option<SecretFormat>,
-  dry_run: bool,
-  replace: bool,
-  yes: bool,
-  json_output: bool,
+  options: ImportOptions<'_>,
 ) -> Result<i32> {
+  let ImportOptions {
+    path,
+    format,
+    dry_run,
+    replace,
+    yes,
+    json_output,
+  } = options;
   let format = SecretFormat::for_input(path, format)?;
   let api = client::human_client(server).await?;
   let env = environment::resolve_environment(&api, reference).await?;

--- a/app/src/cli/commands/init.rs
+++ b/app/src/cli/commands/init.rs
@@ -1,6 +1,6 @@
 use super::output;
 use crate::{
-  cli::{client, dotenv, local_config::ResolvedServer},
+  cli::{client, local_config::ResolvedServer, secret_format},
   constants::api,
 };
 use anyhow::Result;
@@ -8,15 +8,19 @@ use reqwest::Method;
 use serde_json::json;
 use std::path::Path;
 
+use secret_format::SecretFormat;
+
 pub(super) async fn execute(
   server: &ResolvedServer,
   project: String,
   environment: String,
   from: &Path,
+  format: Option<SecretFormat>,
   json_output: bool,
 ) -> Result<i32> {
+  let format = SecretFormat::for_input(from, format)?;
   let api = client::human_client(server).await?;
-  let entries = dotenv::parse_file(from)?;
+  let entries = secret_format::read(from, Some(format))?;
   let data = api
     .request(
       Method::POST,

--- a/app/src/cli/commands/mod.rs
+++ b/app/src/cli/commands/mod.rs
@@ -90,13 +90,15 @@ async fn execute_client(
       project,
       environment,
       from,
-    } => init::execute(server, project, environment, &from, json_output).await,
+      format,
+    } => init::execute(server, project, environment, &from, format, json_output).await,
     Command::Project { command } => project::execute(command, server, json_output).await,
     Command::Env { command } => environment::execute(command, server, json_output).await,
     Command::Secret { command } => secret::execute(command, server, json_output).await,
     Command::Import {
       environment,
       path,
+      format,
       dry_run,
       replace,
       yes,
@@ -105,6 +107,7 @@ async fn execute_client(
         server,
         &environment,
         &path,
+        format,
         dry_run,
         replace,
         yes,
@@ -116,8 +119,20 @@ async fn execute_client(
       environment,
       output,
       stdout,
+      format,
       force,
-    } => export::execute(server, &environment, output, stdout, force, json_output).await,
+    } => {
+      export::execute(
+        server,
+        &environment,
+        output,
+        stdout,
+        format,
+        force,
+        json_output,
+      )
+      .await
+    }
     Command::Token { command } => token::execute(command, server, json_output).await,
     Command::Run {
       environment,

--- a/app/src/cli/commands/mod.rs
+++ b/app/src/cli/commands/mod.rs
@@ -106,12 +106,14 @@ async fn execute_client(
       import::execute(
         server,
         &environment,
-        &path,
-        format,
-        dry_run,
-        replace,
-        yes,
-        json_output,
+        import::ImportOptions {
+          path: &path,
+          format,
+          dry_run,
+          replace,
+          yes,
+          json_output,
+        },
       )
       .await
     }

--- a/app/src/cli/mod.rs
+++ b/app/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod dotenv;
 pub mod local_config;
 #[doc(hidden)]
 pub mod runtime_cache;
+pub mod secret_format;
 #[doc(hidden)]
 pub mod session;
 pub mod update;

--- a/app/src/cli/secret_format.rs
+++ b/app/src/cli/secret_format.rs
@@ -94,6 +94,9 @@ pub fn parse(
   if entries.is_empty() {
     bail!("the input contains no secret entries");
   }
+  if entries.iter().any(|entry| entry.key.is_empty()) {
+    bail!("secret keys may not be empty");
+  }
   Ok(entries)
 }
 

--- a/app/src/cli/secret_format.rs
+++ b/app/src/cli/secret_format.rs
@@ -1,0 +1,325 @@
+use crate::{cli::dotenv, models::SecretInput};
+use anyhow::{Context, Result, bail};
+use clap::ValueEnum;
+use serde::de::{self, DeserializeSeed, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::{collections::BTreeMap, fmt, fs, io::Read, path::Path};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum SecretFormat {
+  Dotenv,
+  Json,
+  Yaml,
+}
+
+impl SecretFormat {
+  pub fn for_input(
+    path: &Path,
+    explicit: Option<Self>,
+  ) -> Result<Self> {
+    if let Some(format) = explicit {
+      return Ok(format);
+    }
+    if path == Path::new("-") {
+      bail!("--format is required when reading secrets from stdin");
+    }
+    Ok(Self::from_path(path))
+  }
+
+  pub fn for_output(
+    path: Option<&Path>,
+    explicit: Option<Self>,
+  ) -> Self {
+    explicit.unwrap_or_else(|| path.map_or(Self::Dotenv, Self::from_path))
+  }
+
+  fn from_path(path: &Path) -> Self {
+    match path
+      .extension()
+      .and_then(|extension| extension.to_str())
+      .map(str::to_ascii_lowercase)
+      .as_deref()
+    {
+      Some("json") => Self::Json,
+      Some("yaml" | "yml") => Self::Yaml,
+      _ => Self::Dotenv,
+    }
+  }
+}
+
+pub fn read(
+  path: &Path,
+  explicit: Option<SecretFormat>,
+) -> Result<Vec<SecretInput>> {
+  let format = SecretFormat::for_input(path, explicit)?;
+  let text = if path == Path::new("-") {
+    let mut text = String::new();
+    std::io::stdin()
+      .read_to_string(&mut text)
+      .context("failed to read secrets from stdin")?;
+    text
+  } else {
+    fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?
+  };
+  parse(&text, format)
+}
+
+pub fn parse(
+  text: &str,
+  format: SecretFormat,
+) -> Result<Vec<SecretInput>> {
+  if text.trim().is_empty() {
+    bail!("the input contains no secret entries");
+  }
+  let entries = match format {
+    SecretFormat::Dotenv => dotenv::parse(text)?,
+    SecretFormat::Json => {
+      let mut deserializer = serde_json::Deserializer::from_str(text);
+      let values = StrictSecretMap::deserialize(&mut deserializer).context("invalid JSON input")?;
+      deserializer.end().context("invalid JSON input")?;
+      values.into_entries()
+    }
+    SecretFormat::Yaml => {
+      let options = serde_saphyr::options! {
+        duplicate_keys: serde_saphyr::DuplicateKeyPolicy::Error,
+        merge_keys: serde_saphyr::MergeKeyPolicy::Error,
+        no_schema: true,
+        with_snippet: false,
+      };
+      serde_saphyr::from_str_with_options::<StrictSecretMap>(text, options)
+        .context("invalid YAML input")?
+        .into_entries()
+    }
+  };
+  if entries.is_empty() {
+    bail!("the input contains no secret entries");
+  }
+  Ok(entries)
+}
+
+pub fn render(
+  entries: &[SecretInput],
+  format: SecretFormat,
+) -> Result<String> {
+  let sorted = entries
+    .iter()
+    .map(|entry| (entry.key.as_str(), entry.value.as_str()))
+    .collect::<BTreeMap<_, _>>();
+  match format {
+    SecretFormat::Dotenv => {
+      let entries = sorted
+        .into_iter()
+        .map(|(key, value)| SecretInput {
+          key: key.into(),
+          value: value.into(),
+        })
+        .collect::<Vec<_>>();
+      Ok(dotenv::render(&entries))
+    }
+    SecretFormat::Json => Ok(format!("{}\n", serde_json::to_string_pretty(&sorted)?)),
+    SecretFormat::Yaml => Ok(serde_saphyr::to_string(&sorted)?),
+  }
+}
+
+struct StrictSecretMap(BTreeMap<String, String>);
+
+impl StrictSecretMap {
+  fn into_entries(self) -> Vec<SecretInput> {
+    self
+      .0
+      .into_iter()
+      .map(|(key, value)| SecretInput { key, value })
+      .collect()
+  }
+}
+
+impl<'de> Deserialize<'de> for StrictSecretMap {
+  fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_map(SecretMapVisitor)
+  }
+}
+
+struct SecretMapVisitor;
+
+impl<'de> Visitor<'de> for SecretMapVisitor {
+  type Value = StrictSecretMap;
+
+  fn expecting(
+    &self,
+    formatter: &mut fmt::Formatter,
+  ) -> fmt::Result {
+    formatter.write_str("a flat mapping of secret names to string values")
+  }
+
+  fn visit_map<A>(
+    self,
+    mut map: A,
+  ) -> std::result::Result<Self::Value, A::Error>
+  where
+    A: MapAccess<'de>,
+  {
+    let mut entries = BTreeMap::new();
+    while let Some(key) = map.next_key_seed(SecretKeySeed)? {
+      if key.is_empty() {
+        return Err(de::Error::custom("secret keys may not be empty"));
+      }
+      if entries.contains_key(&key) {
+        return Err(de::Error::custom(format!("duplicate secret key {key:?}")));
+      }
+      let value = map.next_value_seed(SecretValueSeed { key: &key })?;
+      entries.insert(key, value);
+    }
+    Ok(StrictSecretMap(entries))
+  }
+}
+
+struct SecretKeySeed;
+
+impl<'de> DeserializeSeed<'de> for SecretKeySeed {
+  type Value = String;
+
+  fn deserialize<D>(
+    self,
+    deserializer: D,
+  ) -> std::result::Result<Self::Value, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_any(StringOnlyVisitor {
+      label: "secret key",
+    })
+  }
+}
+
+struct SecretValueSeed<'a> {
+  key: &'a str,
+}
+
+impl<'de> DeserializeSeed<'de> for SecretValueSeed<'_> {
+  type Value = String;
+
+  fn deserialize<D>(
+    self,
+    deserializer: D,
+  ) -> std::result::Result<Self::Value, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    deserializer.deserialize_any(StringOnlyVisitor { label: self.key })
+  }
+}
+
+struct StringOnlyVisitor<'a> {
+  label: &'a str,
+}
+
+impl<'de> Visitor<'de> for StringOnlyVisitor<'_> {
+  type Value = String;
+
+  fn expecting(
+    &self,
+    formatter: &mut fmt::Formatter,
+  ) -> fmt::Result {
+    write!(formatter, "a string for {:?}", self.label)
+  }
+
+  fn visit_str<E>(
+    self,
+    value: &str,
+  ) -> std::result::Result<Self::Value, E> {
+    Ok(value.into())
+  }
+
+  fn visit_string<E>(
+    self,
+    value: String,
+  ) -> std::result::Result<Self::Value, E> {
+    Ok(value)
+  }
+
+  fn visit_bool<E>(
+    self,
+    _value: bool,
+  ) -> std::result::Result<Self::Value, E>
+  where
+    E: de::Error,
+  {
+    Err(self.wrong_type("boolean"))
+  }
+
+  fn visit_i64<E>(
+    self,
+    _value: i64,
+  ) -> std::result::Result<Self::Value, E>
+  where
+    E: de::Error,
+  {
+    Err(self.wrong_type("number"))
+  }
+
+  fn visit_u64<E>(
+    self,
+    _value: u64,
+  ) -> std::result::Result<Self::Value, E>
+  where
+    E: de::Error,
+  {
+    Err(self.wrong_type("number"))
+  }
+
+  fn visit_f64<E>(
+    self,
+    _value: f64,
+  ) -> std::result::Result<Self::Value, E>
+  where
+    E: de::Error,
+  {
+    Err(self.wrong_type("number"))
+  }
+
+  fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+  where
+    E: de::Error,
+  {
+    Err(self.wrong_type("null"))
+  }
+
+  fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+  where
+    E: de::Error,
+  {
+    Err(self.wrong_type("null"))
+  }
+
+  fn visit_seq<A>(
+    self,
+    _sequence: A,
+  ) -> std::result::Result<Self::Value, A::Error>
+  where
+    A: de::SeqAccess<'de>,
+  {
+    Err(self.wrong_type("array"))
+  }
+
+  fn visit_map<A>(
+    self,
+    _map: A,
+  ) -> std::result::Result<Self::Value, A::Error>
+  where
+    A: MapAccess<'de>,
+  {
+    Err(self.wrong_type("object"))
+  }
+}
+
+impl StringOnlyVisitor<'_> {
+  fn wrong_type<E: de::Error>(
+    &self,
+    kind: &str,
+  ) -> E {
+    de::Error::custom(format!("{:?} must be a string, found {kind}", self.label))
+  }
+}

--- a/app/src/constants/help.rs
+++ b/app/src/constants/help.rs
@@ -15,7 +15,7 @@ Quickstart:
   dopbase server start                     # run a server on http://localhost:8840
   dopbase server up                        # run the server in the background
   dopbase login                            # authenticate with the active server
-  dopbase init myapp dev --from .env       # create a project + environment from a dotenv file
+  dopbase init myapp dev --from .env       # create a project + environment from a secrets file
   dopbase secret set myapp/dev API_KEY --stdin
   dopbase run myapp/dev -- node server.js  # run with secrets injected as env vars
 
@@ -45,8 +45,12 @@ Examples:
 pub(crate) const LOGIN_HELP: &str = "Examples:\n  dopbase login\n  dopbase login --token\n  printf '%s' \"$TOKEN\" | dopbase login --token\n";
 pub(crate) const LOGOUT_HELP: &str = "Examples:\n  dopbase logout\n";
 pub(crate) const STATUS_HELP: &str = "Examples:\n  dopbase status\n";
-pub(crate) const INIT_HELP: &str =
-  "Examples:\n  dopbase init payment-service development --from .env\n";
+pub(crate) const INIT_HELP: &str = "\
+Examples:
+  dopbase init payment-service development --from .env
+  dopbase init payment-service development --from secrets.json
+  cat secrets.yml | dopbase init payment-service development --from - --format yaml
+";
 
 pub(crate) const PROJECT_HELP: &str = "\
 Examples:
@@ -152,12 +156,14 @@ Examples:
 pub(crate) const IMPORT_HELP: &str = "\
 Examples:
   dopbase import payment-service/production .env.production
-  dopbase import payment-service/production .env.production --dry-run
+  dopbase import payment-service/production secrets.json --dry-run
+  cat secrets.yml | dopbase import payment-service/production - --format yaml
 ";
 pub(crate) const EXPORT_HELP: &str = "\
 Examples:
   dopbase export payment-service/production --output .env.production
-  dopbase export payment-service/production --stdout
+  dopbase export payment-service/production --output secrets.json
+  dopbase export payment-service/production --stdout --format yaml
 ";
 pub(crate) const RUN_HELP: &str = "\
 Examples:

--- a/app/tests/cli/args.rs
+++ b/app/tests/cli/args.rs
@@ -1,6 +1,7 @@
 use app::cli::args::{AdminCommand, Cli, Command, ServerCommand};
 use app::cli::{
   local_config::{ClientConfig, ResolvedServer, ServerSource},
+  secret_format::SecretFormat,
   session,
 };
 use app::constants::config::executable_environment_names;
@@ -104,7 +105,23 @@ fn parses_every_v0_1_command_shape() {
       ".env",
       "--dry-run",
     ],
+    &[
+      "dopbase",
+      "import",
+      "billing/production",
+      "-",
+      "--format",
+      "json",
+    ],
     &["dopbase", "export", "billing/production", "--stdout"],
+    &[
+      "dopbase",
+      "export",
+      "billing/production",
+      "--stdout",
+      "--format",
+      "yaml",
+    ],
     &[
       "dopbase",
       "token",
@@ -382,6 +399,63 @@ fn rejects_conflicting_file_options() {
     ])
     .is_err()
   );
+}
+
+#[test]
+fn secret_commands_parse_format_options() {
+  let init = Cli::try_parse_from([
+    "dopbase",
+    "init",
+    "storefront",
+    "development",
+    "--from",
+    "-",
+    "--format",
+    "yaml",
+  ])
+  .unwrap();
+  assert!(matches!(
+    init.command,
+    Command::Init {
+      format: Some(SecretFormat::Yaml),
+      ..
+    }
+  ));
+
+  let import = Cli::try_parse_from([
+    "dopbase",
+    "import",
+    "storefront/development",
+    "secrets.data",
+    "--format",
+    "json",
+  ])
+  .unwrap();
+  assert!(matches!(
+    import.command,
+    Command::Import {
+      format: Some(SecretFormat::Json),
+      ..
+    }
+  ));
+
+  let export = Cli::try_parse_from([
+    "dopbase",
+    "export",
+    "storefront/development",
+    "--output",
+    "secrets.yml",
+    "--format",
+    "dotenv",
+  ])
+  .unwrap();
+  assert!(matches!(
+    export.command,
+    Command::Export {
+      format: Some(SecretFormat::Dotenv),
+      ..
+    }
+  ));
 }
 
 #[test]

--- a/app/tests/cli/main.rs
+++ b/app/tests/cli/main.rs
@@ -5,6 +5,7 @@ mod dotenv;
 mod local_config;
 mod output;
 mod runtime_cache;
+mod secret_commands;
 mod secret_format;
 mod session;
 mod update;

--- a/app/tests/cli/main.rs
+++ b/app/tests/cli/main.rs
@@ -5,5 +5,6 @@ mod dotenv;
 mod local_config;
 mod output;
 mod runtime_cache;
+mod secret_format;
 mod session;
 mod update;

--- a/app/tests/cli/secret_commands.rs
+++ b/app/tests/cli/secret_commands.rs
@@ -1,0 +1,179 @@
+use app::cli::{
+  local_config::{ClientConfig, ResolvedServer, ServerSource},
+  session,
+};
+use axum::{Json, Router, extract::State, routing::get};
+use serde_json::{Value, json};
+use std::{
+  io::Write,
+  process::{Command, Stdio},
+  sync::{Arc, Mutex},
+};
+use tempfile::TempDir;
+
+const TOKEN: &str = "dbc_secret-format-test";
+const SECRET_MARKER: &str = "secret-value-marker";
+
+#[derive(Clone, Default)]
+struct CapturedRequests {
+  init: Arc<Mutex<Option<Value>>>,
+  import: Arc<Mutex<Option<Value>>>,
+}
+
+async fn session_handler() -> Json<Value> {
+  Json(json!({"data":{"email":"admin@example.com"}}))
+}
+
+async fn resolve_handler() -> Json<Value> {
+  Json(json!({"data":{"id":"env_01TEST"}}))
+}
+
+async fn init_handler(
+  State(requests): State<CapturedRequests>,
+  Json(body): Json<Value>,
+) -> Json<Value> {
+  *requests.init.lock().unwrap() = Some(body);
+  Json(json!({
+    "data": {
+      "project": {"id":"proj_01TEST"},
+      "environmentId": "env_01TEST",
+      "secretCount": 2
+    }
+  }))
+}
+
+async fn import_handler(
+  State(requests): State<CapturedRequests>,
+  Json(body): Json<Value>,
+) -> Json<Value> {
+  *requests.import.lock().unwrap() = Some(body);
+  Json(json!({
+    "data": {
+      "addedKeys": ["API_KEY", "DATABASE_URL"],
+      "updatedKeys": [],
+      "unchangedKeys": [],
+      "deletedKeys": [],
+      "dryRun": true,
+      "revision": "revision-1"
+    }
+  }))
+}
+
+async fn start_server() -> (CapturedRequests, String, tokio::task::JoinHandle<()>) {
+  let requests = CapturedRequests::default();
+  let router = Router::new()
+    .route("/api/v1/auth/session", get(session_handler))
+    .route("/api/v1/environments/resolve", get(resolve_handler))
+    .route("/api/v1/projects/init", axum::routing::post(init_handler))
+    .route(
+      "/api/v1/environments/{id}/secrets/import",
+      axum::routing::post(import_handler),
+    )
+    .with_state(requests.clone());
+  let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+  let address = listener.local_addr().unwrap();
+  let task = tokio::spawn(async move {
+    axum::serve(listener, router).await.unwrap();
+  });
+  (requests, format!("http://{address}"), task)
+}
+
+fn save_session(
+  directory: &TempDir,
+  url: &str,
+) {
+  let server = ResolvedServer {
+    url: url.into(),
+    source: ServerSource::Argument,
+    config_path: directory.path().join("config.toml"),
+    config: ClientConfig::default(),
+  };
+  session::save(&server, TOKEN, Some("admin@example.com")).unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn init_reads_yaml_from_stdin_and_sends_string_entries() {
+  let (requests, url, server) = start_server().await;
+  let directory = TempDir::new().unwrap();
+  save_session(&directory, &url);
+  let mut child = Command::new(env!("CARGO_BIN_EXE_dopbase"))
+    .args([
+      "--server",
+      &url,
+      "--data-dir",
+      directory.path().to_str().unwrap(),
+      "--json",
+      "init",
+      "storefront",
+      "development",
+      "--from",
+      "-",
+      "--format",
+      "yaml",
+    ])
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .spawn()
+    .unwrap();
+  child
+    .stdin
+    .take()
+    .unwrap()
+    .write_all(format!("API_KEY: {SECRET_MARKER}\nEMPTY: \"\"\n").as_bytes())
+    .unwrap();
+  let output = child.wait_with_output().unwrap();
+  server.abort();
+
+  assert!(output.status.success(), "{output:?}");
+  let body = requests.init.lock().unwrap().clone().unwrap();
+  assert_eq!(body["projectName"], "storefront");
+  assert_eq!(body["environmentName"], "development");
+  assert_eq!(
+    body["entries"][0],
+    json!({"key":"API_KEY","value":SECRET_MARKER})
+  );
+  assert_eq!(body["entries"][1], json!({"key":"EMPTY","value":""}));
+  assert!(!String::from_utf8_lossy(&output.stdout).contains(SECRET_MARKER));
+  assert!(!String::from_utf8_lossy(&output.stderr).contains(SECRET_MARKER));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn import_infers_json_from_the_filename_and_preserves_dry_run() {
+  let (requests, url, server) = start_server().await;
+  let directory = TempDir::new().unwrap();
+  save_session(&directory, &url);
+  let source = directory.path().join("secrets.json");
+  std::fs::write(
+    &source,
+    format!(r#"{{"DATABASE_URL":"{SECRET_MARKER}","API_KEY":"token"}}"#),
+  )
+  .unwrap();
+  let output = Command::new(env!("CARGO_BIN_EXE_dopbase"))
+    .args([
+      "--server",
+      &url,
+      "--data-dir",
+      directory.path().to_str().unwrap(),
+      "--json",
+      "import",
+      "storefront/development",
+      source.to_str().unwrap(),
+      "--dry-run",
+    ])
+    .output()
+    .unwrap();
+  server.abort();
+
+  assert!(output.status.success(), "{output:?}");
+  let body = requests.import.lock().unwrap().clone().unwrap();
+  assert_eq!(body["mode"], "merge");
+  assert_eq!(body["dryRun"], true);
+  assert_eq!(body["entries"][0], json!({"key":"API_KEY","value":"token"}));
+  assert_eq!(
+    body["entries"][1],
+    json!({"key":"DATABASE_URL","value":SECRET_MARKER})
+  );
+  assert!(!String::from_utf8_lossy(&output.stdout).contains(SECRET_MARKER));
+  assert!(!String::from_utf8_lossy(&output.stderr).contains(SECRET_MARKER));
+}

--- a/app/tests/cli/secret_format.rs
+++ b/app/tests/cli/secret_format.rs
@@ -117,8 +117,10 @@ fn rejects_duplicate_keys() {
 #[test]
 fn rejects_empty_keys_and_non_string_values_without_exposing_values() {
   for (text, format, key, kind) in [
+    ("=marker\n", SecretFormat::Dotenv, "", "empty"),
     (r#"{"":"marker"}"#, SecretFormat::Json, "", "empty"),
     (r#"{"PORT":8840}"#, SecretFormat::Json, "PORT", "number"),
+    ("PORT: 8840\n", SecretFormat::Yaml, "PORT", "number"),
     ("ENABLED: true\n", SecretFormat::Yaml, "ENABLED", "boolean"),
     (
       "NESTED:\n  TOKEN: marker\n",

--- a/app/tests/cli/secret_format.rs
+++ b/app/tests/cli/secret_format.rs
@@ -1,0 +1,169 @@
+use app::{
+  cli::secret_format::{SecretFormat, parse, render},
+  models::SecretInput,
+};
+use std::path::Path;
+
+fn entries(values: &[(&str, &str)]) -> Vec<SecretInput> {
+  values
+    .iter()
+    .map(|(key, value)| SecretInput {
+      key: (*key).into(),
+      value: (*value).into(),
+    })
+    .collect()
+}
+
+#[test]
+fn infers_formats_and_preserves_dotenv_fallbacks() {
+  for path in [".env", ".env.production", "secrets", "secrets.txt"] {
+    assert_eq!(
+      SecretFormat::for_input(Path::new(path), None).unwrap(),
+      SecretFormat::Dotenv
+    );
+  }
+  for path in ["secrets.json", "SECRETS.JSON"] {
+    assert_eq!(
+      SecretFormat::for_input(Path::new(path), None).unwrap(),
+      SecretFormat::Json
+    );
+  }
+  for path in ["secrets.yaml", "secrets.yml", "SECRETS.YML"] {
+    assert_eq!(
+      SecretFormat::for_input(Path::new(path), None).unwrap(),
+      SecretFormat::Yaml
+    );
+  }
+}
+
+#[test]
+fn stdin_requires_an_explicit_format() {
+  assert!(
+    SecretFormat::for_input(Path::new("-"), None)
+      .unwrap_err()
+      .to_string()
+      .contains("--format")
+  );
+  assert_eq!(
+    SecretFormat::for_input(Path::new("-"), Some(SecretFormat::Json)).unwrap(),
+    SecretFormat::Json
+  );
+}
+
+#[test]
+fn explicit_format_overrides_the_extension() {
+  assert_eq!(
+    SecretFormat::for_input(Path::new("secrets.json"), Some(SecretFormat::Yaml)).unwrap(),
+    SecretFormat::Yaml
+  );
+  assert_eq!(
+    SecretFormat::for_output(Some(Path::new("secrets.yaml")), Some(SecretFormat::Json)),
+    SecretFormat::Json
+  );
+}
+
+#[test]
+fn parses_all_supported_formats() {
+  assert_eq!(
+    parse("A=one\nB=\"two three\"\n", SecretFormat::Dotenv)
+      .unwrap()
+      .len(),
+    2
+  );
+  assert_eq!(
+    parse(r#"{"A":"one","B":"two three"}"#, SecretFormat::Json)
+      .unwrap()
+      .len(),
+    2
+  );
+  assert_eq!(
+    parse("A: one\nB: \"two three\"\n", SecretFormat::Yaml)
+      .unwrap()
+      .len(),
+    2
+  );
+}
+
+#[test]
+fn rejects_inputs_without_entries() {
+  for (text, format) in [
+    ("\n", SecretFormat::Dotenv),
+    ("# comment\n", SecretFormat::Dotenv),
+    ("{}", SecretFormat::Json),
+    ("{}\n", SecretFormat::Yaml),
+  ] {
+    assert!(
+      parse(text, format)
+        .unwrap_err()
+        .to_string()
+        .contains("no secret entries")
+    );
+  }
+}
+
+#[test]
+fn rejects_duplicate_keys() {
+  for (text, format) in [
+    (r#"{"A":"first","A":"second"}"#, SecretFormat::Json),
+    ("A: first\nA: second\n", SecretFormat::Yaml),
+  ] {
+    let message = format!("{:#}", parse(text, format).unwrap_err());
+    assert!(message.contains("A"), "{message}");
+    assert!(!message.contains("first"), "{message}");
+    assert!(!message.contains("second"), "{message}");
+  }
+}
+
+#[test]
+fn rejects_empty_keys_and_non_string_values_without_exposing_values() {
+  for (text, format, key, kind) in [
+    (r#"{"":"marker"}"#, SecretFormat::Json, "", "empty"),
+    (r#"{"PORT":8840}"#, SecretFormat::Json, "PORT", "number"),
+    ("ENABLED: true\n", SecretFormat::Yaml, "ENABLED", "boolean"),
+    (
+      "NESTED:\n  TOKEN: marker\n",
+      SecretFormat::Yaml,
+      "NESTED",
+      "object",
+    ),
+    ("ITEMS:\n  - marker\n", SecretFormat::Yaml, "ITEMS", "array"),
+    ("NOTHING: null\n", SecretFormat::Yaml, "NOTHING", "null"),
+  ] {
+    let message = format!("{:#}", parse(text, format).unwrap_err());
+    if !key.is_empty() {
+      assert!(message.contains(key), "{message}");
+    }
+    assert!(message.contains(kind), "{message}");
+    assert!(!message.contains("marker"), "{message}");
+  }
+}
+
+#[test]
+fn rejects_multiple_yaml_documents() {
+  assert!(parse("A: one\n---\nB: two\n", SecretFormat::Yaml).is_err());
+}
+
+#[test]
+fn renders_sorted_deterministic_output() {
+  let values = entries(&[("Z_KEY", "last"), ("A_KEY", "true"), ("M_KEY", "two words")]);
+  assert_eq!(
+    render(&values, SecretFormat::Dotenv).unwrap(),
+    "A_KEY=true\nM_KEY=\"two words\"\nZ_KEY=last\n"
+  );
+  assert_eq!(
+    render(&values, SecretFormat::Json).unwrap(),
+    "{\n  \"A_KEY\": \"true\",\n  \"M_KEY\": \"two words\",\n  \"Z_KEY\": \"last\"\n}\n"
+  );
+  let yaml = render(&values, SecretFormat::Yaml).unwrap();
+  assert!(yaml.ends_with('\n'));
+  assert!(yaml.find("A_KEY:").unwrap() < yaml.find("M_KEY:").unwrap());
+  assert!(yaml.find("M_KEY:").unwrap() < yaml.find("Z_KEY:").unwrap());
+  let reparsed = parse(&yaml, SecretFormat::Yaml).unwrap();
+  assert_eq!(
+    reparsed
+      .iter()
+      .map(|entry| (entry.key.as_str(), entry.value.as_str()))
+      .collect::<Vec<_>>(),
+    [("A_KEY", "true"), ("M_KEY", "two words"), ("Z_KEY", "last")]
+  );
+}

--- a/docs/cli/cheat-sheet.md
+++ b/docs/cli/cheat-sheet.md
@@ -49,7 +49,7 @@ examples for `secret set`.
 
 | Task                                   | Command                                              | Command options             | Example                                                |
 | -------------------------------------- | ---------------------------------------------------- | --------------------------- | ------------------------------------------------------ |
-| Create a project and first environment | `dopbase init <PROJECT> <ENVIRONMENT> --from <FILE>` | `--from <FILE>` (required)  | `dopbase init payment-service development --from .env` |
+| Create a project and first environment | `dopbase init <PROJECT> <ENVIRONMENT> --from <FILE\|->` | `--from` is required. `--format <dotenv\|json\|yaml>` overrides inference and is required for stdin | `dopbase init payment-service development --from secrets.json` |
 | Create a project                       | `dopbase project create <NAME>`                      | No command-specific options | `dopbase project create payment-service`               |
 | List projects                          | `dopbase project list`                               | No command-specific options | `dopbase project list`                                 |
 | Show a project                         | `dopbase project show <PROJECT>`                     | No command-specific options | `dopbase project show payment-service`                 |
@@ -72,9 +72,9 @@ examples for `secret set`.
 | Show secret metadata      | `dopbase secret get <ENVIRONMENT> <KEY>`       | No command-specific options                                                                                    | `dopbase secret get payment-service/production API_KEY`                                   |
 | Reveal a secret           | `dopbase secret get <ENVIRONMENT> <KEY>`       | `--reveal` prints the value after password confirmation                                                        | `dopbase secret get payment-service/production API_KEY --reveal`                          |
 | Delete a secret           | `dopbase secret delete <ENVIRONMENT> <KEY>`    | `--yes` skips confirmation                                                                                     | `dopbase secret delete payment-service/production API_KEY --yes`                          |
-| Import a dotenv file      | `dopbase import <ENVIRONMENT> <FILE>`          | `--dry-run` previews changes. `--replace` removes remote keys absent from the file. `--yes` skips confirmation | `dopbase import payment-service/staging .env.staging --dry-run`                           |
-| Export to a file          | `dopbase export <ENVIRONMENT> --output <FILE>` | `--output <FILE>` or `--stdout` is required. `--force` overwrites an existing file                             | `dopbase export payment-service/staging --output .env.staging --force`                    |
-| Export to standard output | `dopbase export <ENVIRONMENT> --stdout`        | `--stdout` conflicts with `--output`                                                                           | `dopbase export payment-service/staging --stdout`                                         |
+| Import a secret file      | `dopbase import <ENVIRONMENT> <FILE\|->`       | Supports dotenv, JSON, and YAML. `--format` is required for stdin. `--dry-run`, `--replace`, and `--yes` keep their existing behavior | `dopbase import payment-service/staging secrets.json --dry-run`                           |
+| Export to a file          | `dopbase export <ENVIRONMENT> --output <FILE>` | `--output` or `--stdout` is required. `--format` overrides inference. `--force` overwrites an existing file | `dopbase export payment-service/staging --output secrets.yml --force`                    |
+| Export to standard output | `dopbase export <ENVIRONMENT> --stdout`        | Defaults to dotenv. Use `--format json` or `--format yaml` for another serialization                         | `dopbase export payment-service/staging --stdout --format json`                          |
 | Run with injected secrets | `dopbase run [ENVIRONMENT] -- <COMMAND>`       | `-t <TOKEN>` or `--token <TOKEN>` overrides other credentials. Everything after `--` is the child command      | `dopbase run payment-service/development -- npm start`                                    |
 
 ## Tokens, backups, and maintenance

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -137,6 +137,8 @@ operation:
 
 ```bash
 dopbase init payment-service development --from .env
+dopbase init worker development --from secrets.json
+cat secrets.yml | dopbase init storefront development --from - --format yaml
 ```
 
 The command validates the complete file before changing server state. The
@@ -208,6 +210,8 @@ Import into an existing environment with:
 
 ```bash
 dopbase import payment-service/staging .env.staging
+dopbase import payment-service/staging secrets.json
+cat secrets.yml | dopbase import payment-service/staging - --format yaml
 ```
 
 Import merges by default: keys in the file are created or updated, while
@@ -219,28 +223,40 @@ Use `--replace` to make the remote environment match the file exactly. Replace
 shows the keys that would be deleted and requires confirmation. Non-interactive
 use also requires `--yes`.
 
-The complete file is parsed and validated before any secret changes are made.
-Blank lines and comments are ignored, empty values are valid, and variable or
-command substitution is not performed. Duplicate or invalid keys fail the
-entire import. Output includes key names and counts when useful, but never
-values.
+The CLI infers JSON from `.json`, YAML from `.yaml` or `.yml`, and dotenv from
+every other filename. This keeps names such as `.env.production` compatible.
+Pass `--format <dotenv|json|yaml>` to override inference. Stdin uses `-` and
+always requires `--format`.
+
+JSON and YAML input must be one flat mapping of string keys to string values.
+Nested objects, arrays, numbers, booleans, null values, duplicate keys, and
+empty keys fail the complete import. Dotenv does not expand variables or run
+command substitutions. All formats allow empty string values but must contain
+at least one secret. Errors may name a key, but never print its value.
 
 Export requires an explicit destination:
 
 ```bash
 dopbase export payment-service/staging --output .env.staging
-dopbase export payment-service/staging --stdout
+dopbase export payment-service/staging --output secrets.json
+dopbase export payment-service/staging --stdout --format yaml
 ```
 
-`--output` and `--stdout` are mutually exclusive. File export refuses to
-overwrite an existing path unless `--force` is passed and creates the file with
-restrictive permissions where the platform supports them. Export and stdout
-reveal plaintext values and therefore require reveal permission and create an
-audit event. The CLI also requires interactive password confirmation for every
-export. Non-interactive export is intentionally rejected.
+`--output` and `--stdout` are mutually exclusive. File output infers its format
+from the filename, while stdout defaults to dotenv. `--format` overrides either
+default. JSON and YAML keys are sorted for stable output. Global `--json`
+controls command status output and cannot be combined with plaintext
+`--stdout`.
 
-The same workflows exist in the Admin UI, with a visual review and dry-run
-summary before anything is stored. See [import and export](/ui/import-export).
+File export refuses to overwrite an existing path unless `--force` is passed
+and creates the file with restrictive permissions where the platform supports
+them. Export and stdout reveal plaintext values and therefore require reveal
+permission and create an audit event. The CLI also requires interactive
+password confirmation for every export. Non-interactive export is rejected.
+
+The Admin UI provides the same workflow for dotenv files, with a visual review
+and dry-run summary before anything is stored. See
+[import and export](/ui/import-export).
 
 ## Runner tokens
 

--- a/docs/guide/backups-and-restore.md
+++ b/docs/guide/backups-and-restore.md
@@ -12,7 +12,7 @@ relying on it for production data.
 :::
 
 Dopbase includes a native, full-system backup and disaster recovery engine. Unlike
-per-environment `.env` export and import, a backup captures the complete server
+per-environment secret export and import, a backup captures the complete server
 state in an encrypted archive: all projects, environments, secret keys and
 version histories, runner tokens, and administrator accounts.
 

--- a/docs/guide/import-env.md
+++ b/docs/guide/import-env.md
@@ -1,19 +1,21 @@
 ---
-title: "Import a .env file"
-description: "Import an existing .env file into Dopbase, create a project from it, and export values back out when you need the file form."
+title: "Import and export secret files"
+description: "Move secrets between Dopbase and dotenv, JSON, or YAML files."
 ---
 
-# Import a `.env` file
+# Import and export secret files
 
-Dopbase treats `.env` as an import and export format. It does not store the
-file as one opaque object.
+Dopbase accepts dotenv, JSON, and YAML files. It parses each file into
+individual secret records instead of storing the file as one opaque object.
 
-## Create a project from `.env`
+## Create a project from a secret file
 
 Use `init` when the project does not exist yet:
 
 ```bash
 dopbase init payment-service development --from .env
+dopbase init another-service development --from secrets.json
+dopbase init worker development --from secrets.yml
 ```
 
 The file is validated first. Dopbase then creates the project, environment, and
@@ -46,9 +48,25 @@ dopbase import payment-service/staging .env.staging --dry-run
 Use `--replace` only when the environment should exactly match the file.
 Dopbase shows which keys would be deleted and requires confirmation or `--yes`.
 
-The parser accepts blank lines, comments, quoted values, and empty values. It
-does not expand variables or execute substitutions. Duplicate or invalid keys
-reject the complete import before any server state changes.
+Dotenv input accepts blank lines, comments, quoted values, and empty values. It
+does not expand variables or execute substitutions. JSON and YAML must contain
+one flat object whose keys and values are strings. Nested objects, arrays,
+numbers, booleans, null values, duplicate keys, and empty keys are rejected.
+Every format must contain at least one secret. Dopbase validates the complete
+input before changing server state.
+
+The format is inferred from `.json`, `.yaml`, and `.yml`. Every other filename,
+including `.env.production`, defaults to dotenv. Use `--format` to override the
+filename or when reading from stdin:
+
+```bash
+dopbase import payment-service/staging secrets.data --format json
+cat secrets.yml | dopbase import payment-service/staging - --format yaml
+cat .env | dopbase init worker development --from - --format dotenv
+```
+
+Stdin imports need an existing valid login or `DOPBASE_TOKEN`. The CLI cannot
+use the same stdin stream for both secret data and an interactive login.
 
 ## Export
 
@@ -56,10 +74,15 @@ Export requires an explicit file or stdout destination:
 
 ```bash
 dopbase export payment-service/staging --output .env.staging
-dopbase export payment-service/staging --stdout
+dopbase export payment-service/staging --output secrets.json
+dopbase export payment-service/staging --stdout --format yaml
 ```
 
-File export refuses to overwrite an existing path without `--force` and uses
+File output uses the filename rules above. Stdout defaults to dotenv. Pass
+`--format` to choose another format. JSON and YAML keys are sorted so repeated
+exports have stable output.
+
+Export refuses to overwrite an existing file without `--force` and uses
 restrictive permissions where supported. Export reveals plaintext values, so
 it is permission-controlled and audited. Every CLI export requires an
 interactive password confirmation. There is no non-interactive bypass.
@@ -67,9 +90,9 @@ interactive password confirmation. There is no non-interactive bypass.
 Prefer [`dopbase run`](./run-an-application) when an application only needs
 secrets in its process environment.
 
-The same import and export workflows are available in the browser. The Admin UI
-parses the file locally, shows a key review and a dry-run summary before
-applying, and downloads exports. See [import and export](/ui/import-export).
+The Admin UI supports dotenv files. It parses the file locally, shows a key
+review and a dry-run summary before applying, and downloads dotenv exports.
+See [import and export](/ui/import-export).
 
 ## Handle values safely
 

--- a/docs/guide/product-status.md
+++ b/docs/guide/product-status.md
@@ -13,7 +13,7 @@ documentation, and SQLite storage in one executable.
 
 - Projects, environments, and individually managed secrets
 - Encryption before persistence with separate master-key material
-- `.env` import and export
+- dotenv, JSON, and YAML import and export through the CLI
 - An embedded browser Admin UI covering setup, sign-in, project and
   environment management, secret management with a `.env` editor, runner
   tokens, audit events, and instance status

--- a/docs/self-hosting/storage-backups.md
+++ b/docs/self-hosting/storage-backups.md
@@ -44,7 +44,7 @@ human users, service accounts, and tokens. Backups from earlier releases are
 not supported.
 
 Dopbase includes a comprehensive system snapshot and restoration engine. Unlike
-per-environment export and import (which only touch secret values in dotenv format),
+per-environment export and import (which only touch secret values),
 the backup system snapshots the entire database: projects, environments, secret
 histories, runner tokens, and administrator accounts.
 

--- a/docs/ui/import-export.md
+++ b/docs/ui/import-export.md
@@ -49,15 +49,16 @@ it belongs, then delete it.
 
 ## Which tool when
 
-The CLI does the same jobs from a terminal:
+The CLI does the same jobs from a terminal and also accepts JSON and YAML:
 
 ```bash
 dopbase import payment-service/staging .env.staging
-dopbase export payment-service/staging --output .env.staging
+dopbase import payment-service/staging secrets.json
+dopbase export payment-service/staging --output secrets.yml
 ```
 
 The command reference covers the CLI flags, including `--dry-run`,
-`--replace`, and `--stdout`. CLI export also requires interactive password
-confirmation for each invocation. See [CLI commands](/cli/commands). Choose
-the interface that fits the workflow. Both write the same records and create
-audit events.
+`--replace`, `--stdout`, and `--format`. CLI export also requires interactive
+password confirmation for each invocation. The browser remains dotenv-only.
+See [CLI commands](/cli/commands). Both interfaces write the same records and
+create audit events.


### PR DESCRIPTION
<!-- pr-template:summary -->

## Summary

Add dotenv, JSON, and YAML support to secret initialization, import, and export. The CLI infers formats from filenames, accepts explicit `--format` overrides, reads init and import data from stdin, and validates JSON and YAML as flat string mappings without exposing secret values.

The change keeps import previews, expected revisions, export password confirmation, overwrite protection, private file permissions, and server schemas unchanged. Public CLI documentation now covers the new formats and notes that the Admin UI remains dotenv-only.

Closes #18

<!-- pr-template:compatibility -->

## Compatibility

Existing dotenv commands remain compatible. Unknown extensions, including `.env.production`, still default to dotenv. Stdout export still defaults to dotenv, and global `--json` remains separate from secret serialization.

No migration is required. The changelog is intentionally left for the next release preparation commit, following the current release workflow.

<!-- pr-template:verification -->

## Verification

- `cargo fmt --manifest-path app/Cargo.toml -- --check`
- `cargo clippy --manifest-path app/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path app/Cargo.toml --locked --all-targets --all-features`
- `bun run docs:build`
- `codegraph sync`

<!-- pr-template:checklist -->

## Checklist

- [x] I kept this pull request focused on one problem.
- [x] I added or updated tests for behavior changes, or explained why tests are not needed.
- [x] I updated the documentation and `CHANGELOG.md` when public behavior changed, or explained why they are not needed.
- [x] I updated relevan documentation inside `/docs`